### PR TITLE
Cas/finish risk scenarios

### DIFF
--- a/tests/test_sensitivity_analysis_patient.py
+++ b/tests/test_sensitivity_analysis_patient.py
@@ -54,13 +54,13 @@ def test_sensitivity_analysis_patient():
         results_df = simulation.get_results_df()
         all_results[analysis_type] = results_df
 
-    assert all_results['temp_basal_only'].carb_value.sum() == 0
-    assert all_results['correction_bolus'].carb_value.sum() == 0
-    assert all_results['meal_bolus'].carb_value[0] == 30
+    assert all_results['temp_basal_only'].true_carb_value.sum() == 0
+    assert all_results['correction_bolus'].true_carb_value.sum() == 0
+    assert all_results['meal_bolus'].true_carb_value[0] == 30
 
-    assert all_results['temp_basal_only'].bolus.sum() == 0
-    assert all_results['correction_bolus'].bolus[1:].sum() == 0
-    assert all_results['meal_bolus'].bolus[1:].sum() == 0
+    assert all_results['temp_basal_only'].true_bolus.sum() == 0
+    assert all_results['correction_bolus'].true_bolus[1:].sum() == 0
+    assert all_results['meal_bolus'].true_bolus[1:].sum() == 0
 
 
 

--- a/tidepool_data_science_simulator/loop_risk_analysis_TLR315.py
+++ b/tidepool_data_science_simulator/loop_risk_analysis_TLR315.py
@@ -11,11 +11,44 @@ Tidepool Loop Risk Card: https://tidepool.atlassian.net/browse/TLR-315
 from datetime import timedelta
 
 from tidepool_data_science_simulator.models.controller import LoopController
+from tidepool_data_science_simulator.models.patient import VirtualPatientCarbBolusAccept
 from tidepool_data_science_simulator.models.measures import Bolus, Carb
 from tidepool_data_science_simulator.makedata.make_patient import get_canonical_risk_patient_config, get_canonical_risk_pump_config
+from tidepool_data_science_simulator.makedata.make_controller import get_canonical_controller_config
 from tidepool_data_science_simulator.makedata.make_simulation import get_canonical_simulation
 from tidepool_data_science_simulator.visualization.sim_viz import plot_sim_results
 from tidepool_data_science_simulator.utils import timing
+
+
+class LoopBolusRecMalfunctionDelay(LoopController):
+    """
+    A Loop controller that exhibits a malfunction delay in the delivery of a
+    recommended bolus. It thinks the bolus was delivered at a particular
+    time but the patient gets it at a later time.
+    """
+
+    def __init__(self, time, controller_config):
+        super().__init__(time, controller_config)
+
+    def set_bolus_recommendation_event(self, virtual_patient, bolus):
+        """
+                Add the accepted bolus event to the virtual patient's timeline to
+                be applied at the next update.
+
+                Parameters
+                ----------
+                virtual_patient
+                bolus
+                """
+        delay_minutes = self.controller_config.bolus_rec_delay_minutes
+        reported_time = self.time + timedelta(minutes=5)
+        delivered_time = reported_time + timedelta(minutes=delay_minutes)
+
+        # Add to patient timeline
+        virtual_patient.bolus_event_timeline.add_event(delivered_time, bolus)
+
+        # Log in pump, which Loop will read at update
+        virtual_patient.pump.bolus_event_timeline.add_event(reported_time, bolus)
 
 
 @timing
@@ -28,50 +61,47 @@ def risk_analysis_tlr315_bolus_report_time_difference():
     scenario_csv_filepath: str
         Path to the scenario file
     """
-    bolus_value_candidates = [1.0]#, 2.0]
-    delay_time_minutes_candidates = [0, 30]#, 60, 90]
+
+    delay_time_minutes_candidates = [30]#, 60, 90]
 
     param_grid = [
         {
-            "bolus_value": bolus_value,
             "delay_time_minutes": delay_time_minutes
         }
-        for bolus_value in bolus_value_candidates
         for delay_time_minutes in delay_time_minutes_candidates
     ]
 
     sims = dict()
     for params in param_grid:
-        bolus_value = params["bolus_value"]
+
         delay_time_minutes = params["delay_time_minutes"]
 
-        sim_id = "tlr315_delay_{}_bolus_{}".format(delay_time_minutes, bolus_value)
+        sim_id = "tlr315_delay_{}".format(delay_time_minutes)
         print("Running: {}".format(sim_id))
 
         sim_num_hours = 24
 
         t0, patient_config = get_canonical_risk_patient_config()
         t0, pump_config = get_canonical_risk_pump_config()
+        t0, controller_config = get_canonical_controller_config()
 
-        patient_config.recommendation_accept_prob = 0.0  # TODO: put in scenario file
+        patient_config.recommendation_accept_prob = 1.0  # Note: Important use here
+        patient_config.min_bolus_rec_threshold = 0.5
 
-        bolus = Bolus(bolus_value, "U")
         carb = Carb(20, "g", 180)
+        carb_time = t0
+        pump_config.carb_event_timeline.add_event(carb_time, carb)
+        patient_config.carb_event_timeline.add_event(carb_time, carb)
 
-        # Reported Bolus
-        reported_bolus_time = t0 + timedelta(minutes=30)
-        pump_config.bolus_event_timeline.add_event(reported_bolus_time, bolus)
-        pump_config.carb_event_timeline.add_event(reported_bolus_time, carb)
-
-        # Delivered Bolus
-        delivered_bolus_time = reported_bolus_time + timedelta(minutes=delay_time_minutes)
-        patient_config.bolus_event_timeline.add_event(delivered_bolus_time, bolus)
-        patient_config.carb_event_timeline.add_event(reported_bolus_time, carb)
+        controller_config.bolus_rec_delay_minutes = delay_time_minutes
 
         t0, sim = get_canonical_simulation(
             t0=t0,
             patient_config=patient_config,
-            controller_class=LoopController,
+            pump_config=pump_config,
+            patient_class=VirtualPatientCarbBolusAccept,
+            controller_class=LoopBolusRecMalfunctionDelay,
+            controller_config=controller_config,
             multiprocess=True,
             duration_hrs=sim_num_hours,
         )

--- a/tidepool_data_science_simulator/loop_risk_analysis_TLR342.py
+++ b/tidepool_data_science_simulator/loop_risk_analysis_TLR342.py
@@ -1,0 +1,90 @@
+__author__ = "Cameron Summers"
+
+"""
+This file to for running risk analysis of Tidepool Loop when a
+there is a time difference when the patient eats carbs vs when it
+was reported to Loop.
+
+Tidepool Loop Risk Card: https://tidepool.atlassian.net/browse/TLR-342
+"""
+
+from datetime import timedelta
+
+from tidepool_data_science_simulator.models.controller import LoopController
+from tidepool_data_science_simulator.models.patient import VirtualPatientCarbBolusAccept
+from tidepool_data_science_simulator.models.measures import Bolus, Carb
+from tidepool_data_science_simulator.makedata.make_patient import get_canonical_risk_patient_config, get_canonical_risk_pump_config
+from tidepool_data_science_simulator.makedata.make_simulation import get_canonical_simulation
+from tidepool_data_science_simulator.visualization.sim_viz import plot_sim_results
+from tidepool_data_science_simulator.utils import timing
+
+
+@timing
+def risk_analysis_tlr342_bolus_report_time_difference():
+    """
+    Compare loop running with an action and without that action.
+
+    Parameters
+    ----------
+    scenario_csv_filepath: str
+        Path to the scenario file
+    """
+    carb_value_candidates = [20.0]
+    delay_time_minutes_candidates = [30, 60, 90]
+
+    param_grid = [
+        {
+            "carb_value": carb_value,
+            "delay_time_minutes": delay_time_minutes
+        }
+        for carb_value in carb_value_candidates
+        for delay_time_minutes in delay_time_minutes_candidates
+    ]
+
+    sims = dict()
+    for params in param_grid:
+        carb_value = params["carb_value"]
+        delay_time_minutes = params["delay_time_minutes"]
+
+        sim_id = "tlr315_delay_{}_carb_{}".format(delay_time_minutes, carb_value)
+        print("Running: {}".format(sim_id))
+
+        sim_num_hours = 24
+
+        t0, patient_config = get_canonical_risk_patient_config()
+        t0, pump_config = get_canonical_risk_pump_config()
+
+        patient_config.recommendation_accept_prob = 1.0  # NOTE. Using Loop bolus recommendation
+        patient_config.min_bolus_rec_threshold = 0.5
+
+        # User reports Carb
+        carb = Carb(20, "g", 180)
+        reported_carb_time = t0 + timedelta(minutes=30)
+        pump_config.carb_event_timeline.add_event(reported_carb_time, carb, input_time=reported_carb_time)
+
+        # User eats Carb at a different time than was reported.
+        actual_carb_time = reported_carb_time + timedelta(minutes=delay_time_minutes)
+        patient_config.carb_event_timeline.add_event(actual_carb_time, carb)
+
+        t0, sim = get_canonical_simulation(
+            t0=t0,
+            patient_config=patient_config,
+            patient_class=VirtualPatientCarbBolusAccept,
+            pump_config=pump_config,
+            controller_class=LoopController,
+            multiprocess=True,
+            duration_hrs=sim_num_hours,
+        )
+
+        sims[sim_id] = sim
+        sim.start()
+
+    all_results = {id: sim.queue.get() for id, sim in sims.items()}
+    [sim.join() for id, sim in sims.items()]
+
+    plot_sim_results(all_results, save=False)
+
+
+if __name__ == "__main__":
+
+    risk_analysis_tlr342_bolus_report_time_difference()

--- a/tidepool_data_science_simulator/models/controller.py
+++ b/tidepool_data_science_simulator/models/controller.py
@@ -234,19 +234,21 @@ class LoopController(BaseControllerClass):
 
     def set_bolus_recommendation_event(self, virtual_patient, bolus):
         """
-        Add the accepted bolus event to the virtual patient's timeline.
+        Add the accepted bolus event to the virtual patient's timeline to
+        be applied at the next update.
 
         Parameters
         ----------
         virtual_patient
         bolus
         """
+        next_time = self.time + datetime.timedelta(minutes=5)
 
         # Add to patient timeline
-        virtual_patient.bolus_event_timeline.add_event(self.time, bolus)
+        virtual_patient.bolus_event_timeline.add_event(next_time, bolus)
 
         # Log in pump, which Loop will read at update
-        virtual_patient.pump.bolus_event_timeline.add_event(self.time, bolus)
+        virtual_patient.pump.bolus_event_timeline.add_event(next_time, bolus)
 
     def modulate_temp_basal(self, virtual_patient, temp_basal):
         """

--- a/tidepool_data_science_simulator/models/controller.py
+++ b/tidepool_data_science_simulator/models/controller.py
@@ -62,14 +62,37 @@ class LoopController(BaseControllerClass):
         self.bolus_event_timeline = controller_config.bolus_event_timeline
         self.temp_basal_event_timeline = controller_config.temp_basal_event_timeline
         self.carb_event_timeline = controller_config.carb_event_timeline
-        #TODO: Fix
 
         self.num_hours_history = 24  # how many hours of recent events to pass to Loop
 
     def get_state(self):
 
-        # TODO: make this a class with convenience functions
-        return self.recommendations
+        return ControllerState(
+            pyloopkit_recommendations=self.recommendations
+        )
+
+    def get_dose_event_timelines(self, virtual_patient):
+        """
+        Retrieve dose data to pass to Pyloopkit.
+
+        Parameters
+        ----------
+        virtual_patient
+
+        Returns
+        -------
+        (BolusTimeline, CarbTimeline, TempBasalTimeline)
+        """
+        # Loop data store for doses is technically on pump in simulator.
+        bolus_event_timeline, carb_event_timeline, temp_basal_event_timeline = \
+            virtual_patient.get_pump_events()
+
+        # Merge Controller-specific data store, e.g. user inputs manual bolus while pump is inactive
+        bolus_event_timeline.merge_timeline(self.bolus_event_timeline)
+        carb_event_timeline.merge_timeline(self.carb_event_timeline)
+        temp_basal_event_timeline.merge_timeline(self.temp_basal_event_timeline)
+
+        return bolus_event_timeline, carb_event_timeline, temp_basal_event_timeline
 
     def prepare_inputs(self, virtual_patient):
         """
@@ -86,18 +109,16 @@ class LoopController(BaseControllerClass):
         """
         glucose_dates, glucose_values = virtual_patient.sensor.get_loop_inputs()
 
-        # Loop data store for doses is synced with pump. TODO: Decouple?
-        pump_bolus_event_timeline, pump_carb_event_timeline, pump_temp_basal_event_timeline = \
-            virtual_patient.get_pump_events()
+        bolus_event_timeline, carb_event_timeline, temp_basal_event_timeline = self.get_dose_event_timelines(virtual_patient)
 
         bolus_dose_types, bolus_dose_values, bolus_start_times, bolus_end_times, bolus_delivered_units = \
-            pump_bolus_event_timeline.get_loop_inputs(self.time, num_hours_history=self.num_hours_history)
+            bolus_event_timeline.get_loop_inputs(self.time, num_hours_history=self.num_hours_history)
 
         temp_basal_dose_types, temp_basal_dose_values, temp_basal_start_times, temp_basal_end_times, temp_basal_delivered_units = \
-            pump_temp_basal_event_timeline.get_loop_inputs(self.time, num_hours_history=self.num_hours_history)
+            temp_basal_event_timeline.get_loop_inputs(self.time, num_hours_history=self.num_hours_history)
 
         carb_values, carb_start_times, carb_durations = \
-            pump_carb_event_timeline.get_loop_inputs(self.time, num_hours_history=self.num_hours_history)
+            carb_event_timeline.get_loop_inputs(self.time, num_hours_history=self.num_hours_history)
 
         basal_rate_values, basal_rate_start_times, basal_rate_durations = \
             virtual_patient.pump.pump_config.basal_schedule.get_loop_inputs()
@@ -242,12 +263,14 @@ class LoopController(BaseControllerClass):
         virtual_patient
         bolus
         """
+        # Note: due to having the patient go "first" in the update loop we have
+        #       to set the bolus at the next update time.
         next_time = self.time + datetime.timedelta(minutes=5)
 
         # Add to patient timeline
         virtual_patient.bolus_event_timeline.add_event(next_time, bolus)
 
-        # Log in pump, which Loop will read at update
+        # Log in pump
         virtual_patient.pump.bolus_event_timeline.add_event(next_time, bolus)
 
     def modulate_temp_basal(self, virtual_patient, temp_basal):
@@ -302,3 +325,11 @@ class LoopControllerDisconnector(LoopController):
         self.time = time
         if self.is_connected():
             super().update(time, **kwargs)
+
+
+class ControllerState(object):
+
+    def __init__(self,
+                 pyloopkit_recommendations
+                 ):
+        self.pyloopkit_recommendations = pyloopkit_recommendations

--- a/tidepool_data_science_simulator/models/events.py
+++ b/tidepool_data_science_simulator/models/events.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from tidepool_data_science_simulator.models.measures import Carb, Bolus, TempBasal
 from tidepool_data_science_simulator.utils import get_bernoulli_trial_uniform_step_prob
-
 from pyloopkit.dose import DoseType
 
 
@@ -153,6 +152,16 @@ class EventTimeline(object):
                 recent_event_times.append(event_time)
 
         return recent_event_times
+
+    def merge_timeline(self, event_timeline):
+        """
+        Merge events from another timeline.
+
+        Parameters
+        ----------
+        event_timeline: EventTimeline
+        """
+        self.events.update(event_timeline.events)
 
 
 class BolusTimeline(EventTimeline):

--- a/tidepool_data_science_simulator/models/measures.py
+++ b/tidepool_data_science_simulator/models/measures.py
@@ -33,6 +33,9 @@ class Measure(object):
 
         return self.value == other.value and self.units == other.units
 
+    def __hash__(self):
+        return hash((self.value, self.units))
+
 
 class MeasureRange(object):
     """
@@ -101,6 +104,9 @@ class TempBasal(BasalRate):
                 self.value == other.value and \
                 self.units == other.units and \
                 self.scheduled_duration_minutes == other.scheduled_duration_minutes
+
+    def __hash__(self):
+        return hash((self.value, self.units, self.scheduled_duration_minutes))
 
     def get_end_time(self):
         """

--- a/tidepool_data_science_simulator/models/patient.py
+++ b/tidepool_data_science_simulator/models/patient.py
@@ -499,6 +499,23 @@ class VirtualPatient(SimulationComponent):
         return "BG: {:.2f}. IOB: {:.2f}. BR {:.2f}".format(self.bg_current, self.iob_current, self.pump.get_basal_rate().value)
 
 
+class VirtualPatientCarbBolusAccept(VirtualPatient):
+    """
+    A vitual patient that does not accept small Loop bolus recommendations. This will encourage recommendations
+    that are related to Carb entries or other insulin-deficient scenarios.
+    """
+
+    def does_accept_bolus_recommendation(self, bolus):
+        does_accept = False
+        u = np.random.random()
+
+        min_bolus_rec_threshold = self.patient_config.min_bolus_rec_threshold
+        if u <= self.patient_config.recommendation_accept_prob and bolus.value >= min_bolus_rec_threshold:
+            does_accept = True
+
+        return does_accept
+
+
 class VirtualPatientModel(VirtualPatient):
     """
     A virtual patient that probabilistically eats meals and probabilistically gives

--- a/tidepool_data_science_simulator/models/pump.py
+++ b/tidepool_data_science_simulator/models/pump.py
@@ -156,12 +156,14 @@ class ContinuousInsulinPump(SimulationComponent):
         cir = self.pump_config.carb_ratio_schedule.get_state()
 
         return PumpState(
-            scheduled_basal_rate,
-            cir,
-            isf,
-            temp_basal_rate,
-            self.basal_insulin_delivered_last_update,
-            self.basal_undelivered_insulin_since_last_update
+            scheduled_basal_rate=scheduled_basal_rate,
+            scheduled_cir=cir,
+            schedule_isf=isf,
+            temp_basal_rate=temp_basal_rate,
+            bolus=self.bolus_event_timeline.get_event(self.time),
+            carb=self.carb_event_timeline.get_event(self.time),
+            delivered_basal_insulin=self.basal_insulin_delivered_last_update,
+            undelivered_basal_insulin=self.basal_undelivered_insulin_since_last_update
         )
 
     def get_basal_rate(self):
@@ -327,6 +329,8 @@ class PumpState(object):
             schedule_isf,
             temp_basal_rate,
             delivered_basal_insulin,
+            bolus,
+            carb,
             undelivered_basal_insulin=0,
     ):
 
@@ -336,6 +340,8 @@ class PumpState(object):
         self.temp_basal_rate = temp_basal_rate
         self.delivered_basal_insulin = delivered_basal_insulin
         self.undelivered_basal_insulin = undelivered_basal_insulin
+        self.bolus = bolus
+        self.carb = carb
 
     def get_temp_basal_rate_value(self, default=None):
         """

--- a/tidepool_data_science_simulator/models/simulation.py
+++ b/tidepool_data_science_simulator/models/simulation.py
@@ -182,13 +182,15 @@ class Simulation(multiprocessing.Process):
         """
         data = []
         for time, simulation_state in self.simulation_results.items():
-            bolus = simulation_state.patient_state.bolus
-            if bolus is None:
-                bolus = Bolus(0, "U")
 
-            carb = simulation_state.patient_state.carb
-            if carb is None:
-                carb = Carb(0, "g", 0)
+            # Patient stuff
+            true_bolus = simulation_state.patient_state.bolus
+            if true_bolus is None:
+                true_bolus = Bolus(0, "U")
+
+            true_carb = simulation_state.patient_state.carb
+            if true_carb is None:
+                true_carb = Carb(0, "g", 0)
 
             # Pump stuff
             pump_state = simulation_state.patient_state.pump_state
@@ -212,6 +214,14 @@ class Simulation(multiprocessing.Process):
                 delivered_basal_insulin = simulation_state.patient_state.pump_state.delivered_basal_insulin
                 undelivered_basal_insulin = simulation_state.patient_state.pump_state.undelivered_basal_insulin
 
+                reported_bolus = pump_state.bolus
+                if reported_bolus is None:
+                    reported_bolus = Bolus(0, "U")
+
+                reported_carb = pump_state.carb
+                if reported_carb is None:
+                    reported_carb = Carb(0, "g", 0)
+
             row = {
                 "time": time,
                 "bg": simulation_state.patient_state.bg,
@@ -225,9 +235,12 @@ class Simulation(multiprocessing.Process):
                 "pump_sbr": pump_sbr,
                 "pump_isf": pump_isf,
                 "pump_cir": pump_cir,
-                "bolus": bolus.value,
-                "carb_value": carb.value,
-                "carb_duration": carb.duration_minutes,
+                "true_bolus": true_bolus.value,
+                "true_carb_value": true_carb.value,
+                "true_carb_duration": true_carb.duration_minutes,
+                "reported_bolus": reported_bolus.value,
+                "reported_carb_value": reported_carb.value,
+                "reported_carb_duration": reported_carb.duration_minutes,
                 "delivered_basal_insulin": delivered_basal_insulin,
                 "undelivered_basal_insulin": undelivered_basal_insulin
             }

--- a/tidepool_data_science_simulator/models/simulation.py
+++ b/tidepool_data_science_simulator/models/simulation.py
@@ -202,17 +202,17 @@ class Simulation(multiprocessing.Process):
             delivered_basal_insulin = None
             undelivered_basal_insulin = None
             if pump_state is not None:
-                temp_basal_value = simulation_state.patient_state.pump_state.get_temp_basal_rate_value(
+                temp_basal_value = pump_state.get_temp_basal_rate_value(
                     default=None
                 )
-                temp_basal_time_remaining = simulation_state.patient_state.pump_state.get_temp_basal_minutes_left(
+                temp_basal_time_remaining = pump_state.get_temp_basal_minutes_left(
                     time
                 )
-                pump_sbr = simulation_state.patient_state.pump_state.scheduled_basal_rate
-                pump_isf = simulation_state.patient_state.pump_state.scheduled_insulin_sensitivity_factor
-                pump_cir = simulation_state.patient_state.pump_state.scheduled_carb_insulin_ratio
-                delivered_basal_insulin = simulation_state.patient_state.pump_state.delivered_basal_insulin
-                undelivered_basal_insulin = simulation_state.patient_state.pump_state.undelivered_basal_insulin
+                pump_sbr = pump_state.scheduled_basal_rate
+                pump_isf = pump_state.scheduled_insulin_sensitivity_factor
+                pump_cir = pump_state.scheduled_carb_insulin_ratio
+                delivered_basal_insulin = pump_state.delivered_basal_insulin
+                undelivered_basal_insulin = pump_state.undelivered_basal_insulin
 
                 reported_bolus = pump_state.bolus
                 if reported_bolus is None:

--- a/tidepool_data_science_simulator/visualization/sim_viz.py
+++ b/tidepool_data_science_simulator/visualization/sim_viz.py
@@ -17,8 +17,10 @@ def plot_sim_results(all_results, save=False):
     fig, ax = plt.subplots(3, 1, figsize=(16, 20))
     for sim_id, ctrl_result_df in all_results.items():
 
-        ax[0].plot(ctrl_result_df["bg"], label="{} {}".format("bg", sim_id))
-        ax[0].plot(ctrl_result_df["bg_sensor"], label="{} {}".format("bg_sensor", sim_id))
+        ax[0].plot(ctrl_result_df["bg"], label="{} {}".format("bg", sim_id), color="purple")
+        ax[0].scatter(range(len(ctrl_result_df)), ctrl_result_df["bg_sensor"], 4,
+                      label="{} {}".format("bg_sensor", sim_id),
+                      color="green")
         ax[0].set_title("BG Over Time")
         ax[0].set_xlabel("Time (5min)")
         ax[0].set_ylabel("BG (mg/dL)")
@@ -30,17 +32,19 @@ def plot_sim_results(all_results, save=False):
         # ax[0].axhline(median - std, label="BG Std {}".format(std), color="green")
         ax[0].legend()
 
-        ax[1].plot(ctrl_result_df["sbr"], label="{} {}".format("sbr", sim_id))
         ax[1].set_title("Insulin")
         ax[1].set_ylabel("Insulin (U or U/hr)")
         ax[1].set_xlabel("Time (5 mins)")
+        ax[1].plot(ctrl_result_df["sbr"], label="{} {}".format("sbr", sim_id), linestyle="--")
         ax[1].plot(ctrl_result_df["temp_basal"], label="{} {}".format("tmp_br", sim_id))
-        ax[1].plot(ctrl_result_df["bolus"], label="{} {}".format("bolus", sim_id))
+        ax[1].stem(ctrl_result_df["true_bolus"], label="{} {}".format("true bolus", sim_id))
+        ax[1].stem(ctrl_result_df["reported_bolus"], linefmt='g--', markerfmt='X', label="{} {}".format("reported bolus", sim_id))
         ax[1].plot(ctrl_result_df["iob"], label="{} {}".format("iob", sim_id))
         ax[1].set_ylim((0, 3))
         ax[1].legend()
 
-        ax[2].plot(ctrl_result_df["carb_value"], label="{} {}".format("carb", sim_id))
+        ax[2].stem(ctrl_result_df["true_carb_value"], label="{} {}".format("true carb", sim_id))
+        ax[2].stem(ctrl_result_df["reported_carb_value"], linefmt='g--', markerfmt='X', label="{} {}".format("reported carb", sim_id))
         ax[2].set_title("Carb Events")
         ax[2].set_ylabel("Carbs (g)")
         ax[2].set_xlabel("Time (5 mins)")


### PR DESCRIPTION
Last changes supporting 4 scenarios for FDA risk analysis, e.g. enabling Loop specific event reporting without a pump, supporting times for user input of events in addition to the event time, and surfacing differences between what is reported and what has happened.