### PR TITLE
Cas/delete data hotfix

### DIFF
--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,6 +1,6 @@
 __author__ = "Eden Grown-Haeberli"
 
-import datetime
+from datetime import timedelta
 
 from tidepool_data_science_simulator.models.simulation import Simulation
 from tidepool_data_science_simulator.makedata.make_patient import get_canonical_risk_patient
@@ -9,11 +9,17 @@ from tidepool_data_science_simulator.models.controller import LoopController
 from tidepool_data_science_simulator.models.pump import ContinuousInsulinPump
 from tidepool_data_science_simulator.models.events import ActionTimeline, VirtualPatientDeleteLoopData
 
+from tidepool_data_science_simulator.makedata.scenario_parser import ScenarioParserCSV
+from tidepool_data_science_simulator.models.patient import VirtualPatient
+from tidepool_data_science_simulator.models.sensor import IdealSensor
+
+from tidepool_data_science_models.models.simple_metabolism_model import SimpleMetabolismModel
+
 
 def test_virtual_patient_delete():
 
     t0, vp = get_canonical_risk_patient(pump_class=ContinuousInsulinPump)
-    action_time = t0 + datetime.timedelta(minutes=30)
+    action_time = t0 + timedelta(minutes=30)
     vp.action_timeline = ActionTimeline()
     vp.action_timeline.add_event(action_time, VirtualPatientDeleteLoopData("Deleted Insulin History"))
 
@@ -35,3 +41,66 @@ def test_virtual_patient_delete():
 
     assert vp.pump.temp_basal_event_timeline.is_empty_timeline()
     assert vp.pump.bolus_event_timeline.is_empty_timeline()
+
+
+def test_virtual_patient_delete_with_scenario_file():
+
+    scenario_csv_filepath = "tests/data/Scenario-0-simulation-template - inputs.tsv"
+    sim_parser = ScenarioParserCSV(scenario_csv_filepath)
+    t0 = sim_parser.get_simulation_start_time()
+
+    controller = LoopController(
+        time=t0,
+        controller_config=sim_parser.get_controller_config(),
+    )
+    controller.num_hours_history = 8  # Force 8 hours to look for historical boluses
+
+    pump = ContinuousInsulinPump(time=t0, pump_config=sim_parser.get_pump_config())
+    sensor = IdealSensor(time=t0, sensor_config=sim_parser.get_sensor_config())
+
+    vp = VirtualPatient(
+        time=t0,
+        pump=pump,
+        sensor=sensor,
+        metabolism_model=SimpleMetabolismModel,
+        patient_config=sim_parser.get_patient_config(),
+    )
+
+    action_time = t0 + timedelta(minutes=30)
+    vp.action_timeline = ActionTimeline()
+    vp.action_timeline.add_event(action_time, VirtualPatientDeleteLoopData("Deleted Insulin History"))
+
+    _, controller_config = get_canonical_controller_config()
+
+    controller = LoopController(
+        time=t0,
+        controller_config=controller_config
+    )
+
+    simulation = Simulation(
+            time=t0,
+            duration_hrs=8.0,
+            virtual_patient=vp,
+            controller=controller
+    )
+
+    before_action_time = action_time - timedelta(minutes=5)
+    simulation.run(early_stop_datetime=before_action_time)
+
+    assert len(vp.pump.temp_basal_event_timeline.get_recent_event_times(action_time, num_hours_history=0.5)) != 0
+    assert len(vp.pump.bolus_event_timeline.get_recent_event_times(action_time, num_hours_history=0.5)) != 0
+
+    simulation.run(early_stop_datetime=action_time)
+
+    assert len(vp.pump.temp_basal_event_timeline.get_recent_event_times(action_time, num_hours_history=0.5)) == 0
+    assert len(vp.pump.bolus_event_timeline.get_recent_event_times(action_time, num_hours_history=0.5)) == 0
+
+    after_action_time = action_time + timedelta(minutes=30)
+    simulation.run(early_stop_datetime=after_action_time)
+
+    # We've gone 30 minutes past the delete event to make sure the
+    assert len(vp.pump.temp_basal_event_timeline.get_recent_event_times(action_time, num_hours_history=0.5)) == 0
+    assert len(vp.pump.bolus_event_timeline.get_recent_event_times(action_time, num_hours_history=0.5)) == 0
+
+    assert len(vp.pump.temp_basal_event_timeline.get_recent_event_times(after_action_time, num_hours_history=0.5)) != 0
+    assert len(vp.pump.bolus_event_timeline.get_recent_event_times(after_action_time, num_hours_history=0.5)) != 0

--- a/tests/test_sensitivity_analysis_patient.py
+++ b/tests/test_sensitivity_analysis_patient.py
@@ -60,7 +60,8 @@ def test_sensitivity_analysis_patient():
 
     assert all_results['temp_basal_only'].true_bolus.sum() == 0
     assert all_results['correction_bolus'].true_bolus[1:].sum() == 0
-    assert all_results['meal_bolus'].true_bolus[1:].sum() == 0
+    # CAS - Fix/update 2020-08-12 - Bolus recs come in on next patient time
+    assert all_results['meal_bolus'].true_bolus[2:].sum() == 0
 
 
 

--- a/tidepool_data_science_simulator/makedata/scenario_parser.py
+++ b/tidepool_data_science_simulator/makedata/scenario_parser.py
@@ -305,8 +305,10 @@ class ScenarioParserCSV(SimulationParser):
         controller_settings = self.tmp_dict["settings_dictionary"]
 
         controller_config = ControllerConfig(
-            bolus_event_timeline=self.pump_bolus_events,
-            carb_event_timeline=self.pump_carb_events,
+            bolus_event_timeline=BolusTimeline(),
+            carb_event_timeline=CarbTimeline(),
+            # bolus_event_timeline=self.pump_bolus_events,
+            # carb_event_timeline=self.pump_carb_events,
             controller_settings=controller_settings
         )
 


### PR DESCRIPTION
Issue brought up a possible bug in https://tidepool.atlassian.net/projects/TLR/board?issue-key=TLR-337. I looked into it and since 
1) The controller is initialized with the bolus/carb data
2) The controller is now being used to simulation for "manual" inputs of data into Loop
The delete data action didn't work as expected since the controller was initialized with pump events in the scenario file. The fix is to not add any pump events to the controller config, since this wasn't ever necessary. The change required one fix for an icgm test and another test was added to more rigorously test the user deleting data action.