### PR TITLE
[feature] TRSET-24: populate loop glucose-pred/counteraction/COB colu…

### DIFF
--- a/tests/test_loop_prediction_columns_integration.py
+++ b/tests/test_loop_prediction_columns_integration.py
@@ -1,0 +1,156 @@
+"""End-to-end integration test for TRSET-24 Loop prediction/effect/COB columns.
+
+Runs a real ``loop_risk_v2_0`` scenario config through the actual parser and the
+real Swift ``.dylib`` (no mocks) and asserts on the resulting ``get_results_df()``
+dataframe at the system boundary. The harness config is the ``TLR-000-swift``
+median suite, whose three stages exercise both Loop-active (SwiftLoopController)
+and Loop-inactive (DoNothingController) paths in a single run.
+
+Run under the arm64 conda env ``tidepool-data-science-simulator`` (the one that
+matches the committed .dylib). The module skips cleanly when the dylib isn't
+importable, so the suite stays portable.
+"""
+import datetime
+import os
+
+import pytest
+
+# Importing the api module loads the .dylib at import time (ctypes.CDLL); an
+# incompatible/missing dylib raises OSError, not ImportError -- catch broadly.
+try:
+    import loop_to_python_api.api  # noqa: F401
+    _DYLIB_AVAILABLE = True
+    _DYLIB_ERR = ""
+except Exception as e:  # pragma: no cover - env-dependent
+    _DYLIB_AVAILABLE = False
+    _DYLIB_ERR = repr(e)
+
+pytestmark = pytest.mark.skipif(
+    not _DYLIB_AVAILABLE,
+    reason=f"loop_to_python_api / .dylib not available in this env: {_DYLIB_ERR}",
+)
+
+from tidepool_data_science_simulator.makedata.scenario_json_parser_v2 import ScenarioParserV2
+from tidepool_data_science_simulator.models.swift_controller import SwiftLoopController
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CONFIG = os.path.join(
+    REPO_ROOT,
+    "scenario_configs/tidepool_risk_v2/loop_risk_v2_0/test/TLR-000-swift",
+    "Simulation-Configuration-TLR-000-base_median_profile_v1.json",
+)
+
+RUN_HOURS = 1  # early-stop keeps the run near the ~1-min budget
+
+# Columns that have NO Swift API source (D1) + the deprecated bolus column (D5):
+# these must remain empty everywhere -- no fabrication (AC#3).
+UNBACKED_COLUMNS = [
+    "loop_final_insulin_effect",
+    "loop_final_carb_effect",
+    "loop_final_momentum_effect",
+    "loop_final_rc_effect",
+    "loop_recommended_bolus_value",
+]
+
+# Columns the feature newly populates from the Swift prediction API.
+PREDICTION_COLUMNS = [
+    "loop_final_glucose_pred",
+    "loop_final_counteraction_effect",
+    "loop_cob",
+]
+
+
+@pytest.fixture(scope="module")
+def sim_results(tmp_path_factory):
+    """Run the three-stage suite once (early-stopped) and return {sim_id: results_df}."""
+    io_dir = str(tmp_path_factory.mktemp("loop_algo_io"))
+    parser = ScenarioParserV2(path_to_json_config=CONFIG)
+    sims = parser.get_sims()
+
+    results = {}
+    for sim_id, sim in sims.items():
+        if hasattr(sim.controller, "loop_algo_io_dir"):
+            sim.controller.loop_algo_io_dir = io_dir
+        stop = sim.start_time + datetime.timedelta(hours=RUN_HOURS)
+        sim.run(early_stop_datetime=stop)
+        results[sim_id] = (sim, sim.get_results_df())
+    return results
+
+
+def _loop_sim(sim_results):
+    """The post-Loop (SwiftLoopController) stage."""
+    for sim_id, (sim, df) in sim_results.items():
+        if isinstance(sim.controller, SwiftLoopController) and "post-Loop" in sim_id:
+            return df
+    pytest.fail("No post-Loop SwiftLoopController stage found in the suite")
+
+
+def _nonloop_sim(sim_results):
+    """The no-Loop (DoNothingController) stage."""
+    for sim_id, (sim, df) in sim_results.items():
+        if not isinstance(sim.controller, SwiftLoopController):
+            return df
+    pytest.fail("No non-Swift (DoNothing) stage found in the suite")
+
+
+# --- AC#1 / AC#5: the TRSET-21 blocker is cleared ----------------------------
+
+def test_glucose_pred_populated_on_active_loop_steps(sim_results):
+    df = _loop_sim(sim_results)
+    active = df[df["active"] == 1]
+    assert len(active) > 0
+    pred = active["loop_final_glucose_pred"]
+    # Every active Loop step has a predicted glucose value...
+    assert pred.notna().all(), "loop_final_glucose_pred has gaps on active Loop steps"
+    # ...and they are physiologically plausible mg/dL values.
+    assert ((pred >= 10) & (pred <= 600)).all()
+
+
+# --- AC#2: counteraction + COB populate --------------------------------------
+
+def test_cob_and_counteraction_populated_on_active_loop_steps(sim_results):
+    df = _loop_sim(sim_results)
+    active = df[df["active"] == 1]
+    assert active["loop_final_counteraction_effect"].notna().all()
+    # COB is populated on every active step; 0.0 is legitimate, so also require
+    # that carbs are genuinely on board at some step (config carries carb doses).
+    assert active["loop_cob"].notna().all()
+    assert (active["loop_cob"] > 0).any(), "expected COB > 0 at some active step"
+
+
+# --- AC#3: no fabrication where Loop isn't automating ------------------------
+
+def test_no_prediction_data_on_donothing_stage(sim_results):
+    df = _nonloop_sim(sim_results)
+    for col in PREDICTION_COLUMNS:
+        assert df[col].isna().all(), f"{col} fabricated on a non-Loop stage"
+
+
+def test_unbacked_columns_stay_empty_everywhere(sim_results):
+    for _sim_id, (_sim, df) in sim_results.items():
+        for col in UNBACKED_COLUMNS:
+            assert df[col].isna().all(), f"{col} unexpectedly populated (D1/D5)"
+
+
+# --- AC#6: existing populated columns unchanged ------------------------------
+
+def test_existing_columns_still_populated(sim_results):
+    df = _loop_sim(sim_results)
+    active = df[df["active"] == 1]
+    # Recommendation-backed temp basal columns still fill on active Swift steps.
+    assert active["loop_recommended_temp_basal_value"].notna().all()
+    assert active["loop_temp_basal_duration_sec"].notna().all()
+    # Core patient columns unaffected.
+    assert df["bg"].notna().all()
+    assert active["iob"].notna().all()
+
+
+# --- D2: loop_prediction_abs_error_* stays out of scope ----------------------
+
+def test_abs_error_columns_remain_out_of_scope(sim_results):
+    # Storing predictions on a new ControllerState field (not the recommendation
+    # dict) must NOT quietly activate the horizon abs-error columns.
+    df = _loop_sim(sim_results)
+    abs_err_cols = [c for c in df.columns if c.startswith("loop_prediction_abs_error")]
+    for col in abs_err_cols:
+        assert df[col].isna().all(), f"{col} activated -- D2 scope boundary breached"

--- a/tests/test_loop_prediction_extraction.py
+++ b/tests/test_loop_prediction_extraction.py
@@ -1,0 +1,175 @@
+"""Unit tests for TRSET-24 Loop prediction/effect/COB column population.
+
+These are dylib-free: they exercise (a) the pure mapping from a controller's
+``prediction_output`` payload to the ``get_results_df()`` columns, (b) the
+no-silent-swallow logging behaviour, and (c) the controller wiring with the
+Swift prediction API patched to sentinels. The end-to-end run against the real
+.dylib lives in ``test_loop_prediction_columns_integration.py``.
+"""
+import datetime
+import logging
+import types
+
+import pytest
+
+from tidepool_data_science_simulator.models.controller import ControllerState, OpenLoopController
+from tidepool_data_science_simulator.models.simulation import Simulation, SimulationState
+from tidepool_data_science_simulator.models.state import VirtualPatientState, PumpState
+from tidepool_data_science_simulator.models import swift_controller as swift_mod
+from tidepool_data_science_simulator.models.swift_controller import SwiftLoopController
+
+
+T0 = datetime.datetime(2019, 8, 15, 12, 0, 0)
+
+
+def _patient_state():
+    """Minimal but complete patient state for get_results_df()."""
+    return VirtualPatientState(
+        bg=120.0, sensor_bg=118.0, iob=1.25, ei=0.0, pump_state=PumpState()
+    )
+
+
+def _results_df(controller_state, active=1):
+    """Run only get_results_df() over a one-step results dict (no full Simulation)."""
+    results = {
+        T0: SimulationState(
+            patient_state=_patient_state(),
+            controller_state=controller_state,
+            randint=0,
+            active=active,
+        )
+    }
+    sim_like = types.SimpleNamespace(simulation_results=results)
+    return Simulation.get_results_df(sim_like)
+
+
+# --- U1: payload maps to the right columns -----------------------------------
+
+def test_prediction_output_maps_to_columns():
+    payload = {
+        "predicted_glucose_values": [300.0, 250.0, 180.0, 99.81],
+        "predicted_glucose_dates": ["a", "b", "c", "d"],
+        "glucose_effect_velocity_values": [0.0, 1.0, 2.5],
+        "active_carbs": 12.0,
+        "active_insulin": 0.0064,
+    }
+    rec = {"automatic": {"bolusUnits": 0.0, "basalAdjustment": {"unitsPerHour": 0.5, "duration": 1800}}}
+    df = _results_df(ControllerState(pyloopkit_recommendations=rec, prediction_output=payload))
+
+    row = df.loc[T0]
+    assert row["loop_final_glucose_pred"] == 99.81            # final value convention
+    assert row["loop_final_counteraction_effect"] == 2.5      # final ICE value
+    assert row["loop_cob"] == 12.0
+    # existing recommendation-backed columns unchanged
+    assert row["loop_automatic_bolus_rec"] == 0.0
+    assert row["loop_recommended_temp_basal_value"] == 0.5
+    assert row["loop_temp_basal_duration_sec"] == 1800
+
+
+def test_cob_zero_is_preserved_not_treated_as_missing():
+    payload = {
+        "predicted_glucose_values": [110.0, 110.0],
+        "glucose_effect_velocity_values": [0.0],
+        "active_carbs": 0.0,
+        "active_insulin": 0.0,
+    }
+    df = _results_df(ControllerState(pyloopkit_recommendations=None, prediction_output=payload))
+    assert df.loc[T0]["loop_cob"] == 0.0
+
+
+# --- AC#3 / D1 / D5: no fabrication where data doesn't exist ------------------
+
+def test_no_prediction_output_leaves_prediction_columns_none():
+    """DoNothing-style step: recommendation present, no prediction payload."""
+    df = _results_df(ControllerState(pyloopkit_recommendations=None, prediction_output=None))
+    row = df.loc[T0]
+    for col in ["loop_final_glucose_pred", "loop_final_counteraction_effect", "loop_cob"]:
+        assert row[col] is None
+
+
+def test_unbacked_effect_columns_and_bolus_value_stay_none():
+    """D1: the four effect columns have no API source. D5: loop_recommended_bolus_value deprecated."""
+    payload = {
+        "predicted_glucose_values": [120.0],
+        "glucose_effect_velocity_values": [0.0],
+        "active_carbs": 0.0,
+        "active_insulin": 0.0,
+    }
+    df = _results_df(ControllerState(pyloopkit_recommendations={"automatic": {"bolusUnits": 1.0}},
+                                     prediction_output=payload))
+    row = df.loc[T0]
+    for col in ["loop_final_insulin_effect", "loop_final_carb_effect",
+                "loop_final_momentum_effect", "loop_final_rc_effect",
+                "loop_recommended_bolus_value"]:
+        assert row[col] is None
+
+
+# --- U2a: no silent swallow in get_results_df --------------------------------
+
+def test_malformed_prediction_output_is_logged_not_swallowed(caplog):
+    # prediction_output is a list -> `.get` raises AttributeError inside the try.
+    bad_state = ControllerState(pyloopkit_recommendations=None, prediction_output=["not", "a", "dict"])
+    with caplog.at_level(logging.WARNING, logger="tidepool_data_science_simulator.models.simulation"):
+        df = _results_df(bad_state)
+    assert any("Error extracting loop outputs" in r.message for r in caplog.records)
+    # degrades gracefully: columns are empty, no exception raised
+    assert df.loc[T0]["loop_final_glucose_pred"] is None
+
+
+# --- U3: controller wiring reuses the same input dict ------------------------
+
+def test_compute_prediction_output_assembles_payload_from_same_dict(monkeypatch):
+    seen = {}
+    sentinel_dict = {"predictionStart": "2019-08-15T12:00:00Z"}
+
+    monkeypatch.setattr(swift_mod, "get_prediction_values_and_dates",
+                        lambda d: (seen.setdefault("pred", d), ([300.0, 99.0], ["a", "b"]))[1])
+    monkeypatch.setattr(swift_mod, "get_glucose_velocity_values_and_dates",
+                        lambda d: (seen.setdefault("ice", d), ([0.0, 2.0], ["a", "b"]))[1])
+    monkeypatch.setattr(swift_mod, "get_active_carbs",
+                        lambda d: (seen.setdefault("cob", d), 7.5)[1])
+    monkeypatch.setattr(swift_mod, "get_active_insulin",
+                        lambda d: (seen.setdefault("iob", d), 0.5)[1])
+
+    controller = SwiftLoopController.__new__(SwiftLoopController)  # bypass heavy __init__
+    controller.time = T0
+    payload = controller._compute_prediction_output(sentinel_dict)
+
+    assert payload["predicted_glucose_values"] == [300.0, 99.0]
+    assert payload["glucose_effect_velocity_values"] == [0.0, 2.0]
+    assert payload["active_carbs"] == 7.5
+    assert payload["active_insulin"] == 0.5
+    # DRY: every API function received the *same* dict object, no rebuild
+    for key in ["pred", "ice", "cob", "iob"]:
+        assert seen[key] is sentinel_dict
+
+
+# --- U2b: controller prediction failure logs and returns None ----------------
+
+def test_compute_prediction_output_logs_and_returns_none_on_failure(monkeypatch, caplog):
+    def boom(_d):
+        raise RuntimeError("dylib blew up")
+
+    monkeypatch.setattr(swift_mod, "get_prediction_values_and_dates", boom)
+    controller = SwiftLoopController.__new__(SwiftLoopController)
+    controller.time = T0
+
+    with caplog.at_level(logging.WARNING, logger="tidepool_data_science_simulator.models.swift_controller"):
+        result = controller._compute_prediction_output({"x": 1})
+
+    assert result is None
+    assert any("Loop prediction extraction failed" in r.message for r in caplog.records)
+
+
+# --- U4: gating -- non-Swift controllers never expose prediction data --------
+
+def test_controller_state_defaults_prediction_output_none():
+    assert ControllerState(pyloopkit_recommendations={}).prediction_output is None
+
+
+def test_openloop_controller_state_has_no_prediction_output():
+    controller = OpenLoopController.__new__(OpenLoopController)  # bypass heavy __init__
+    controller.recommendations = {"automatic": {"bolusUnits": 0}}
+    controller.prediction_output = None  # set by LoopController.__init__ in real use
+    state = controller.get_state()
+    assert state.prediction_output is None

--- a/tidepool_data_science_simulator/models/controller.py
+++ b/tidepool_data_science_simulator/models/controller.py
@@ -112,6 +112,9 @@ class LoopController(BaseControllerClass):
         self.time = time
         self.controller_config = copy.deepcopy(controller_config)
         self.recommendations = None
+        # Swift-only prediction/effect/COB payload for the current step; populated by
+        # SwiftLoopController, left None by controllers that don't compute predictions.
+        self.prediction_output = None
         self.open_loop = False
 
         self.bolus_event_timeline = controller_config.bolus_event_timeline
@@ -129,7 +132,10 @@ class LoopController(BaseControllerClass):
 
     def get_state(self):
 
-        return ControllerState(pyloopkit_recommendations=self.recommendations)
+        return ControllerState(
+            pyloopkit_recommendations=self.recommendations,
+            prediction_output=self.prediction_output,
+        )
 
     def get_dose_event_timelines(self, virtual_patient):
         """
@@ -504,8 +510,12 @@ class LoopControllerDisconnector(LoopController):
 
 class ControllerState(object):
 
-    def __init__(self, pyloopkit_recommendations):
+    def __init__(self, pyloopkit_recommendations, prediction_output=None):
         self.pyloopkit_recommendations = pyloopkit_recommendations
+        # dict | None: Swift Loop prediction/effect/COB payload for this step
+        # (predicted_glucose_values, glucose_effect_velocity_values, active_carbs,
+        # active_insulin). None for controllers that don't compute predictions.
+        self.prediction_output = prediction_output
 
 
 

--- a/tidepool_data_science_simulator/models/simulation.py
+++ b/tidepool_data_science_simulator/models/simulation.py
@@ -295,88 +295,41 @@ class Simulation(multiprocessing.Process):
 
             if simulation_state.controller_state is not None:
                 try:
+                    # Recommendation object (Swift format): source the three columns it
+                    # legitimately carries -- automatic bolus, temp basal rate, duration.
                     loop_out = simulation_state.controller_state.pyloopkit_recommendations
-                    
                     if loop_out is not None:
-                        # Check if this is Swift Loop API format (has 'automatic' and 'manual' keys)
                         if 'automatic' in loop_out and isinstance(loop_out['automatic'], dict):
                             automatic = loop_out['automatic']
-                            
-                            # Extract automatic bolus recommendation
                             loop_automatic_bolus_rec = automatic.get('bolusUnits')
-                            
-                            # Extract temp basal recommendation
                             if 'basalAdjustment' in automatic and isinstance(automatic['basalAdjustment'], dict):
                                 basal_adj = automatic['basalAdjustment']
                                 loop_temp_basal_rec = basal_adj.get('unitsPerHour')
                                 loop_temp_basal_duration_sec = basal_adj.get('duration')
-                        
-                        # Extract manual bolus recommendation
+
                         if 'manual' in loop_out and isinstance(loop_out['manual'], dict):
                             loop_manual_bolus_rec = loop_out['manual'].get('amount')
-                        
-                        # Legacy pyloopkit format support (if data exists in that format)
-                        # Try different possible key names for COB
-                        loop_cob = loop_out.get("carbs_on_board") or loop_out.get("carbsOnBoard") or loop_out.get("cob")
-                        
-                        # Extract glucose predictions (if available)
-                        pred_values = loop_out.get("predicted_glucose_values") or loop_out.get("predictedGlucoseValues")
-                        if pred_values and len(pred_values) > 0:
-                            pred_horizon_minutes = len(pred_values) * 5
+
+                    # Prediction/effect/COB come from the Swift prediction API payload
+                    # (TRSET-24), NOT the recommendation object -- the recommendation
+                    # never carried these. Populated only on Swift-controlled steps.
+                    pred_out = getattr(simulation_state.controller_state, "prediction_output", None)
+                    if pred_out is not None:
+                        pred_values = pred_out.get("predicted_glucose_values")
+                        if pred_values:
                             final_predicted_glucose = pred_values[-1]
-                        
-                        # Extract insulin effect (if available)
-                        insulin_values = loop_out.get("insulin_effect_values") or loop_out.get("insulinEffectValues")
-                        if insulin_values and len(insulin_values) > 0:
-                            insulin_effect_horizon_minutes = len(insulin_values) * 5
-                            final_insulin_effect = insulin_values[-1]
-                        
-                        # Extract carb effect (if available)
-                        carb_values = loop_out.get("carb_effect_values") or loop_out.get("carbEffectValues")
-                        if carb_values and len(carb_values) > 0:
-                            carb_effect_horizon_minutes = len(carb_values) * 5
-                            final_carb_effect = carb_values[-1]
-                        
-                        # Extract counteraction effect (if available)
-                        counter_values = loop_out.get("counteraction_effect_values") or loop_out.get("counteractionEffectValues")
-                        if counter_values and len(counter_values) > 0:
-                            counteraction_effect_horizon_minutes = len(counter_values) * 5
-                            final_counteraction_effect = counter_values[-1]
-                        
-                        # Extract momentum effect (if available)
-                        momentum_values = loop_out.get("momentum_effect_values") or loop_out.get("momentumEffectValues")
-                        if momentum_values and len(momentum_values) > 0:
-                            momentum_effect_horizon_minutes = len(momentum_values) * 5
-                            final_momentum_effect = momentum_values[-1]
-                        
-                        # Extract retrospective correction effect (if available)
-                        rc_values = loop_out.get("retrospective_effect_values") or loop_out.get("retrospectiveEffectValues")
-                        if rc_values and len(rc_values) > 0:
-                            rc_effect_horizon_minutes = len(rc_values) * 5
-                            final_rc_effect = rc_values[-1]
-                        
-                        # Extract legacy format recommendations (if available)
-                        temp_basal = loop_out.get("recommended_temp_basal") or loop_out.get("recommendedTempBasal")
-                        if temp_basal and len(temp_basal) > 0:
-                            if loop_temp_basal_rec is None:  # Only use if Swift format didn't provide it
-                                loop_temp_basal_rec = temp_basal[0]
-                        
-                        bolus = loop_out.get("recommended_bolus") or loop_out.get("recommendedBolus")
-                        if bolus and len(bolus) > 0:
-                            if loop_bolus_rec is None:  # Only use if Swift format didn't provide it
-                                loop_bolus_rec = bolus[0]
-                    
-                    elif simulation_state.active == 1:
-                        # Only log if this should have data (active=1) - minimal logging
-                        pass
-                
-                except (AttributeError, TypeError, KeyError, IndexError) as e:
-                    # Silently handle expected extraction errors
-                    pass
+
+                        ice_values = pred_out.get("glucose_effect_velocity_values")
+                        if ice_values:
+                            final_counteraction_effect = ice_values[-1]
+
+                        # COB is a scalar; 0.0 is a legitimate value (no active carbs).
+                        loop_cob = pred_out.get("active_carbs")
+
                 except Exception as e:
-                    # Log unexpected errors only
-                    if simulation_state.active == 1:
-                        logger.warning(f"Unexpected error extracting loop outputs at {time}: {e}")
+                    # No silent failures (workflow section 4 / AC #4): log and continue
+                    # with empty loop columns for this step rather than swallowing.
+                    logger.warning("Error extracting loop outputs at %s: %s", time, e)
             # No logging needed when controller_state is None - that's expected during init
 
             row = {

--- a/tidepool_data_science_simulator/models/swift_controller.py
+++ b/tidepool_data_science_simulator/models/swift_controller.py
@@ -1,6 +1,7 @@
 
 import datetime
 import json
+import logging
 import os
 
 
@@ -9,7 +10,16 @@ from tidepool_data_science_simulator.models.controller import AutomationControlT
 
 from tidepool_data_science_simulator import USE_LOCAL_PYLOOPKIT
 
-from loop_to_python_api.api import get_loop_recommendations
+from loop_to_python_api.api import (
+    get_loop_recommendations,
+    get_prediction_values_and_dates,
+    get_glucose_velocity_values_and_dates,
+    get_active_carbs,
+    get_active_insulin,
+)
+
+logger = logging.getLogger(__name__)
+
 
 class SwiftLoopController(LoopController):
     """
@@ -83,11 +93,23 @@ class SwiftLoopController(LoopController):
         # Read the controller insulin model from config; fall back to 'novolog' for
         # backward compatibility with configs that pre-date the 'model' setting.
         data['recommendationInsulinType'] = settings_dictionary.get('model', 'novolog')
+        # maxBasalRate / maxBolus are required by the Swift AlgorithmInputFixture
+        # decoder (non-optional `decode`), so index them directly -- a missing one
+        # is a genuine config error and the KeyError should surface it clearly.
         data['maxBasalRate'] = settings_dictionary['max_basal_rate']
         data['maxBolus'] = settings_dictionary['max_bolus']
         data['suspendThreshold'] = settings_dictionary['suspend_threshold']
-        data['automaticBolusApplicationFactor'] = settings_dictionary['partial_application_factor']
-        data['useMidAbsorptionISF'] = settings_dictionary['use_mid_absorption_isf']
+        # automaticBolusApplicationFactor is optional on the Swift side (Double?,
+        # defaults to nil) and is only meaningful in automaticBolus mode. Include
+        # it only when the config actually provides partial_application_factor;
+        # when omitted, Swift falls back to nil rather than an arbitrary default.
+        # (The recommendationType guard below keys off the same setting.)
+        if 'partial_application_factor' in settings_dictionary:
+            data['automaticBolusApplicationFactor'] = settings_dictionary['partial_application_factor']
+        # useMidAbsorptionISF is an optional flag on the Swift side
+        # (decodeIfPresent ... ?? false); mirror that default when the config
+        # omits it instead of raising.
+        data['useMidAbsorptionISF'] = settings_dictionary.get('use_mid_absorption_isf', False)
         # Default to 2.0 for backward compatibility if not specified
         data['maxActiveInsulinMultiplier'] = settings_dictionary.get('max_active_insulin_multiplier', 2.0)
 
@@ -199,12 +221,52 @@ class SwiftLoopController(LoopController):
         return data
 
     
+    def _compute_prediction_output(self, loop_inputs_dict: dict) -> dict:
+        """Compute the Swift Loop prediction/effect/COB payload for the current step.
+
+        Calls the Swift prediction API with the *same* input dict already built for the
+        recommendation call (DRY -- no second ``prepare_inputs()`` build). Uses the
+        ``*_values_and_dates`` wrappers, which size to the real series length rather than
+        the raw entry points' fixed ``len=72`` default.
+
+        Parameters
+        ----------
+        loop_inputs_dict : dict
+            The Swift Loop input structure produced by ``prepare_inputs()``.
+
+        Returns
+        -------
+        dict | None
+            Payload with ``predicted_glucose_values`` / ``predicted_glucose_dates``
+            (lists), ``glucose_effect_velocity_values`` (list, counteraction/ICE),
+            ``active_carbs`` (float COB) and ``active_insulin`` (float IOB); or ``None``
+            if the prediction API call fails.
+        """
+        try:
+            pred_values, pred_dates = get_prediction_values_and_dates(loop_inputs_dict)
+            ice_values, _ice_dates = get_glucose_velocity_values_and_dates(loop_inputs_dict)
+            return {
+                "predicted_glucose_values": pred_values,
+                "predicted_glucose_dates": pred_dates,
+                "glucose_effect_velocity_values": ice_values,
+                "active_carbs": get_active_carbs(loop_inputs_dict),
+                "active_insulin": get_active_insulin(loop_inputs_dict),
+            }
+        except Exception as e:
+            # Explicit: log and continue with no prediction data for this step.
+            # Never swallow silently (workflow section 4 / AC #4).
+            logger.warning("Loop prediction extraction failed at %s: %s", self.time, e)
+            return None
+
     def get_loop_recommendations(self, time, virtual_patient=None):
         """
         Get recommendations from the Loop Algorithm, based on
         virtual_patient dosing and glucose.
         """
         self.time = time
+        # Reset each step so stale predictions never leak into a step that
+        # doesn't produce a fresh recommendation.
+        self.prediction_output = None
 
         automation_control_event = self.automation_control_timeline.get_event(time)
 
@@ -243,10 +305,19 @@ class SwiftLoopController(LoopController):
             swift_output = get_loop_recommendations(loop_inputs_dict)
             swift_output_decode = swift_output.decode('utf-8')
             swift_output_json = json.loads(swift_output_decode)
-            
+
             # Write out output dict to file
             with open(output_filename, 'w') as f:
                 json.dump(swift_output_json, f, indent=4)
+
+            # Compute the prediction/effect/COB payload from the SAME input dict
+            # (DRY), but ONLY when Loop produced a recommendation. Degenerate inputs
+            # (e.g. glucoseTooOld) make Loop return null AND make the prediction/COB
+            # entry points hard-trap the process -- an uncatchable native crash. A
+            # valid recommendation means the prediction machinery is safe to call.
+            # This is also the perf gate: DoNothing/OpenLoop controllers never reach here.
+            if swift_output_json is not None:
+                self.prediction_output = self._compute_prediction_output(loop_inputs_dict)
 
             return swift_output_json
         


### PR DESCRIPTION
…mns from Swift prediction API; add ControllerState.prediction_output; gate on valid recommendation; log extraction failures

Populate loop_final_glucose_pred, loop_final_counteraction_effect and loop_cob in get_results_df() from the Swift prediction API (generate_prediction / glucose_effect_velocity / active_carbs), stored on a new ControllerState.prediction_output field. Predictions reuse the recommendation's input dict (DRY) and are computed only after Loop returns a valid recommendation -- degenerate input (glucoseTooOld) makes the prediction/COB entry points hard-trap the process. Blanket except:pass replaced with explicit logging.

Notes: loop_final_{insulin,carb,momentum,rc}_effect and loop_recommended_bolus_value stay None (no Swift API source / deprecated). loop_prediction_abs_error_* unchanged. Also includes a carried-over, unrelated config-decoding fix in swift_controller (optional automaticBolusApplicationFactor / useMidAbsorptionISF handling).