### PR TITLE
[feature] TRSET-21: trace-tier reader (contract/data layer)

### DIFF
--- a/tests/test_trace_reader.py
+++ b/tests/test_trace_reader.py
@@ -1,0 +1,174 @@
+"""Unit tests for the TRSET-21 trace-tier reader (isolation).
+
+Exercises the reader against synthetic TSVs written to disk -- validates
+alignment, NaN preservation, tolerance of the variable trailing
+``loop_prediction_abs_error_*`` columns, and every explicit error path.
+
+The integration test (``test_trace_reader_integration.py``) covers the real
+``loop_risk_v2_0`` boundary; here we keep inputs synthetic and self-contained.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from tidepool_data_science_simulator.trace.reader import (
+    FIELD_TO_COLUMN,
+    TIME_COLUMN,
+    SimulationTrace,
+    TraceReadError,
+    read_trace,
+)
+
+SERIES_COLUMNS = list(FIELD_TO_COLUMN.values())
+
+
+def _write_tsv(df, path):
+    """Write a df to a tab-separated .tsv the way save_df() does (index first)."""
+    df.to_csv(path, sep="\t", index=False)
+    return str(path)
+
+
+def _base_frame():
+    """A minimal, contract-complete 3-row frame with a datetime time column."""
+    times = pd.to_datetime(
+        ["2019-08-15T12:00:00Z", "2019-08-15T12:05:00Z", "2019-08-15T12:10:00Z"]
+    )
+    data = {TIME_COLUMN: times}
+    for i, col in enumerate(SERIES_COLUMNS):
+        data[col] = [float(i), float(i) + 1.0, float(i) + 2.0]
+    return pd.DataFrame(data)
+
+
+def test_reads_all_first_class_fields(tmp_path):
+    path = _write_tsv(_base_frame(), tmp_path / "sim-abc.tsv")
+
+    trace = read_trace(path)
+
+    assert isinstance(trace, SimulationTrace)
+    assert trace.sim_id == "sim-abc"
+    assert isinstance(trace.time, pd.DatetimeIndex)
+    assert len(trace.time) == 3
+    # Every series is present, aligned to the time axis, correct length.
+    for field in FIELD_TO_COLUMN:
+        series = getattr(trace, field)
+        assert isinstance(series, pd.Series)
+        assert series.index.equals(trace.time)
+        assert len(series) == 3
+
+
+def test_series_values_match_source_columns(tmp_path):
+    df = _base_frame()
+    path = _write_tsv(df, tmp_path / "sim-values.tsv")
+
+    trace = read_trace(path)
+
+    for field, column in FIELD_TO_COLUMN.items():
+        np.testing.assert_array_equal(
+            getattr(trace, field).to_numpy(), df[column].to_numpy()
+        )
+
+
+def test_time_is_parsed_to_datetime(tmp_path):
+    path = _write_tsv(_base_frame(), tmp_path / "sim-time.tsv")
+
+    trace = read_trace(path)
+
+    assert pd.api.types.is_datetime64_any_dtype(trace.time)
+    assert trace.time[0] == pd.Timestamp("2019-08-15T12:00:00Z")
+
+
+def test_empty_cells_preserved_as_nan_not_forward_filled(tmp_path):
+    df = _base_frame()
+    # Sparse loop_cob: only the middle row has a value (AC #4).
+    df["loop_cob"] = [np.nan, 7.5, np.nan]
+    path = _write_tsv(df, tmp_path / "sim-sparse.tsv")
+
+    trace = read_trace(path)
+
+    assert np.isnan(trace.loop_cob.iloc[0])
+    assert trace.loop_cob.iloc[1] == 7.5
+    assert np.isnan(trace.loop_cob.iloc[2])  # not forward-filled from row 1
+
+
+def test_entirely_empty_loop_cob_tolerated(tmp_path):
+    df = _base_frame()
+    df["loop_cob"] = [np.nan, np.nan, np.nan]  # non-active-Loop stage
+    path = _write_tsv(df, tmp_path / "sim-nocob.tsv")
+
+    trace = read_trace(path)  # must not raise (AC #4)
+
+    assert trace.loop_cob.isna().all()
+
+
+def test_tolerates_variable_abs_error_columns(tmp_path):
+    df = _base_frame()
+    # These trailing columns appear only on some rows in real output; the reader
+    # targets named columns and must ignore them (Known Constraints).
+    df["loop_prediction_abs_error_30_ago_true"] = [np.nan, 4.0, np.nan]
+    df["loop_prediction_abs_error_30_ago_sensor"] = [np.nan, 5.0, np.nan]
+    path = _write_tsv(df, tmp_path / "sim-abserr.tsv")
+
+    trace = read_trace(path)
+
+    assert len(trace.time) == 3
+    # No forecast/abs-error field leaks onto the trace object (AC #5).
+    assert not any("abs_error" in f for f in FIELD_TO_COLUMN)
+
+
+def test_no_prediction_field_exposed():
+    # AC #5: the dataclass carries no prediction/forecast field of any kind.
+    field_names = {f for f in FIELD_TO_COLUMN}
+    assert not any(
+        key in name for name in field_names for key in ("pred", "forecast")
+    )
+
+
+def test_missing_expected_column_raises(tmp_path):
+    df = _base_frame().drop(columns=["iob"])
+    path = _write_tsv(df, tmp_path / "sim-missing.tsv")
+
+    with pytest.raises(TraceReadError, match="missing expected columns.*iob"):
+        read_trace(path)
+
+
+def test_missing_time_column_raises(tmp_path):
+    df = _base_frame().drop(columns=[TIME_COLUMN])
+    path = _write_tsv(df, tmp_path / "sim-notime.tsv")
+
+    with pytest.raises(TraceReadError, match="missing the required 'time' column"):
+        read_trace(path)
+
+
+def test_nonexistent_file_raises(tmp_path):
+    with pytest.raises(TraceReadError, match="does not exist"):
+        read_trace(tmp_path / "nope.tsv")
+
+
+def test_empty_file_raises(tmp_path):
+    path = tmp_path / "sim-empty.tsv"
+    path.write_text("")
+
+    with pytest.raises(TraceReadError, match="empty"):
+        read_trace(str(path))
+
+
+def test_header_only_file_raises(tmp_path):
+    path = tmp_path / "sim-headeronly.tsv"
+    header = "\t".join([TIME_COLUMN] + SERIES_COLUMNS) + "\n"
+    path.write_text(header)
+
+    with pytest.raises(TraceReadError, match="no data rows"):
+        read_trace(str(path))
+
+
+def test_unparseable_time_column_raises(tmp_path):
+    df = _base_frame()
+    df[TIME_COLUMN] = ["not-a-date", "also-bad", "still-bad"]
+    path = _write_tsv(df, tmp_path / "sim-badtime.tsv")
+
+    with pytest.raises(TraceReadError, match="unparseable 'time' column"):
+        read_trace(path)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_trace_reader_integration.py
+++ b/tests/test_trace_reader_integration.py
@@ -1,0 +1,140 @@
+"""End-to-end integration test for the TRSET-21 trace-tier reader.
+
+Runs a real ``loop_risk_v2_0`` scenario config through the actual parser and the
+real Swift ``.dylib`` (no mocks), writes each run's ``get_results_df()`` to a
+genuine tab-separated ``<sim_id>.tsv`` on disk (the same format ``save_df()``
+produces), then reads it back with ``read_trace()`` and asserts the resulting
+:class:`SimulationTrace` matches the file at the boundary -- not mocked.
+
+The harness config is the ``TLR-000-swift`` median suite, whose stages exercise
+both Loop-active (SwiftLoopController) and Loop-inactive (DoNothingController)
+paths, so the reader is validated on both populated and empty ``loop_cob``.
+
+Run under the arm64 conda env ``tidepool-data-science-simulator`` (the one that
+matches the committed .dylib). The module skips cleanly when the dylib isn't
+importable, so the suite stays portable.
+"""
+import datetime
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# Importing the api module loads the .dylib at import time (ctypes.CDLL); an
+# incompatible/missing dylib raises OSError, not ImportError -- catch broadly.
+try:
+    import loop_to_python_api.api  # noqa: F401
+    _DYLIB_AVAILABLE = True
+    _DYLIB_ERR = ""
+except Exception as e:  # pragma: no cover - env-dependent
+    _DYLIB_AVAILABLE = False
+    _DYLIB_ERR = repr(e)
+
+pytestmark = pytest.mark.skipif(
+    not _DYLIB_AVAILABLE,
+    reason=f"loop_to_python_api / .dylib not available in this env: {_DYLIB_ERR}",
+)
+
+from tidepool_data_science_simulator.makedata.scenario_json_parser_v2 import ScenarioParserV2
+from tidepool_data_science_simulator.trace.reader import (
+    FIELD_TO_COLUMN,
+    SimulationTrace,
+    read_trace,
+)
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CONFIG = os.path.join(
+    REPO_ROOT,
+    "scenario_configs/tidepool_risk_v2/loop_risk_v2_0/test/TLR-000-swift",
+    "Simulation-Configuration-TLR-000-base_median_profile_v1.json",
+)
+
+RUN_HOURS = 1  # early-stop keeps the run near the ~1-min budget
+
+
+@pytest.fixture(scope="module")
+def trace_fixtures(tmp_path_factory):
+    """Run the suite once, write each sim to a real .tsv, and return per-sim
+    ``(tsv_path, source_df, trace)`` triples keyed by sim_id."""
+    io_dir = str(tmp_path_factory.mktemp("loop_algo_io"))
+    tsv_dir = str(tmp_path_factory.mktemp("trace_tsv"))
+    parser = ScenarioParserV2(path_to_json_config=CONFIG)
+    sims = parser.get_sims()
+
+    fixtures = {}
+    for sim_id, sim in sims.items():
+        if hasattr(sim.controller, "loop_algo_io_dir"):
+            sim.controller.loop_algo_io_dir = io_dir
+        stop = sim.start_time + datetime.timedelta(hours=RUN_HOURS)
+        sim.run(early_stop_datetime=stop)
+
+        df = sim.get_results_df()  # time is the index, matching save_df()
+        tsv_path = os.path.join(tsv_dir, "{}.tsv".format(sim_id))
+        df.to_csv(tsv_path, sep="\t")  # exactly what utils.save_df() writes
+
+        fixtures[sim_id] = (tsv_path, df, read_trace(tsv_path))
+    assert fixtures, "no sims produced by the harness config"
+    return fixtures
+
+
+def test_returns_simulation_trace_for_each_run(trace_fixtures):
+    for sim_id, (tsv_path, _df, trace) in trace_fixtures.items():
+        assert isinstance(trace, SimulationTrace)
+        # sim_id is derived from the file stem.
+        assert trace.sim_id == os.path.splitext(os.path.basename(tsv_path))[0]
+
+
+def test_time_axis_matches_file(trace_fixtures):
+    for _sim_id, (_tsv_path, df, trace) in trace_fixtures.items():
+        assert isinstance(trace.time, pd.DatetimeIndex)
+        assert len(trace.time) == len(df)
+        expected = pd.DatetimeIndex(pd.to_datetime(df.index))
+        assert trace.time.equals(expected)
+
+
+def test_every_series_matches_source_column_at_the_boundary(trace_fixtures):
+    """The core AC #8 assertion: each trace series equals the on-disk column."""
+    for _sim_id, (tsv_path, _df, trace) in trace_fixtures.items():
+        # Re-read the file independently so the comparison is against the file,
+        # not the in-memory df the trace was built from.
+        on_disk = pd.read_csv(tsv_path, sep="\t")
+        assert len(trace.time) == len(on_disk)
+        for field, column in FIELD_TO_COLUMN.items():
+            np.testing.assert_allclose(
+                getattr(trace, field).to_numpy(dtype=float),
+                on_disk[column].to_numpy(dtype=float),
+                equal_nan=True,
+                err_msg="series '{}' diverged from column '{}'".format(field, column),
+            )
+
+
+def test_core_series_populated(trace_fixtures):
+    """BG/IOB/basal are populated on every run regardless of controller."""
+    for _sim_id, (_tsv_path, _df, trace) in trace_fixtures.items():
+        assert trace.bg.notna().all()
+        assert trace.iob.notna().any()
+        assert trace.sbr.notna().any()
+
+
+def test_loop_cob_tolerated_whether_populated_or_empty(trace_fixtures):
+    """AC #4: reader tolerates loop_cob on both active and inactive stages."""
+    populated_somewhere = False
+    for _sim_id, (_tsv_path, _df, trace) in trace_fixtures.items():
+        # Never raises regardless of sparsity; presence varies by stage.
+        assert len(trace.loop_cob) == len(trace.time)
+        if trace.loop_cob.notna().any():
+            populated_somewhere = True
+    # The median suite includes an active-Loop stage, so COB shows up somewhere.
+    assert populated_somewhere, "expected loop_cob populated on the active-Loop stage"
+
+
+def test_no_prediction_field_on_trace(trace_fixtures):
+    """AC #5: no prediction/forecast attribute is exposed on the trace object."""
+    _sim_id, (_tsv_path, _df, trace) = next(iter(trace_fixtures.items()))
+    attrs = set(vars(trace))
+    assert not any(k in a for a in attrs for k in ("pred", "forecast"))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tidepool_data_science_simulator/trace/__init__.py
+++ b/tidepool_data_science_simulator/trace/__init__.py
@@ -1,0 +1,13 @@
+"""Trace-tier data layer for simulator GUI work (TRSET-21).
+
+Pure read-and-shape layer: parses a single simulator run's ``<sim_id>.tsv``
+output into a typed :class:`SimulationTrace`. No plotting, no Streamlit, no file
+writes -- consumed by the TRSET-22 renderer and TRSET-23 Streamlit integration.
+"""
+from tidepool_data_science_simulator.trace.reader import (
+    SimulationTrace,
+    TraceReadError,
+    read_trace,
+)
+
+__all__ = ["SimulationTrace", "TraceReadError", "read_trace"]

--- a/tidepool_data_science_simulator/trace/reader.py
+++ b/tidepool_data_science_simulator/trace/reader.py
@@ -1,0 +1,179 @@
+"""Trace-tier reader (TRSET-21).
+
+Parse a single simulator run's ``<sim_id>.tsv`` output into a structured,
+typed :class:`SimulationTrace` exposing the history time series that back a
+Loop-home-screen-style visualization: true/sensor BG, IOB, basal, boluses,
+carbs, and COB.
+
+This is a *read-only consumer* of the TSV contract defined by
+``models.simulation.Simulation.get_results_df()`` and written by
+``utils.save_df()`` (tab-separated, with the ``time`` index as the first
+column). It selects columns *by name*, so it tolerates the variable trailing
+``loop_prediction_abs_error_*`` columns that appear on only some rows.
+
+Deliberately excluded: any prediction/forecast series. The TSV stores only a
+per-timestamp scalar endpoint (``loop_final_glucose_pred`` = the last value of
+Loop's forecast per step), not the full forecast array, so a forward-projecting
+forecast line is not reconstructable from current output. Exposing it would
+require persisting the full ``predicted_glucose_values`` array at the source --
+its own follow-up ticket, not built here.
+"""
+import os
+from dataclasses import dataclass, fields
+
+import pandas as pd
+
+# The time axis every series aligns to. Written by save_df() as the first
+# (index) column of the TSV.
+TIME_COLUMN = "time"
+
+# Maps each first-class trace field to the TSV column it is sourced from. The
+# field names are the SimulationTrace attributes; the values are the
+# get_results_df() column names. Every one of these columns must be present in
+# the file (AC #6); their *cells* may be empty (AC #4).
+FIELD_TO_COLUMN = {
+    # BG
+    "bg": "bg",
+    "bg_sensor": "bg_sensor",
+    # IOB
+    "iob": "iob",
+    # Basal
+    "sbr": "sbr",
+    "temp_basal": "temp_basal",
+    # Boluses
+    "true_bolus": "true_bolus",
+    "reported_bolus": "reported_bolus",
+    # Carbs
+    "true_carb_value": "true_carb_value",
+    "reported_carb_value": "reported_carb_value",
+    # COB -- may be sparse or entirely empty on non-active-Loop stages (AC #4).
+    "loop_cob": "loop_cob",
+}
+
+
+class TraceReadError(ValueError):
+    """Raised when a ``<sim_id>.tsv`` cannot be read or is missing the contract.
+
+    Subclasses ``ValueError`` so callers may catch either. Carries an
+    informative message naming the file and the specific problem -- never a
+    silent failure (workflow section 4 / AC #6).
+    """
+
+
+@dataclass(frozen=True)
+class SimulationTrace:
+    """Typed trace of one simulator run's history series.
+
+    All series share ``time`` as their index. Missing/empty cells are ``NaN``
+    (never fabricated or forward-filled). No prediction/forecast field is
+    exposed -- see the module docstring.
+    """
+
+    sim_id: str
+    time: pd.DatetimeIndex
+    # BG
+    bg: pd.Series
+    bg_sensor: pd.Series
+    # IOB
+    iob: pd.Series
+    # Basal
+    sbr: pd.Series
+    temp_basal: pd.Series
+    # Boluses
+    true_bolus: pd.Series
+    reported_bolus: pd.Series
+    # Carbs
+    true_carb_value: pd.Series
+    reported_carb_value: pd.Series
+    # COB
+    loop_cob: pd.Series
+
+
+def read_trace(path) -> SimulationTrace:
+    """Read one ``<sim_id>.tsv`` into a :class:`SimulationTrace`.
+
+    Parameters
+    ----------
+    path : str or os.PathLike
+        Path to a single simulator run's tab-separated ``.tsv`` output.
+
+    Returns
+    -------
+    SimulationTrace
+        The run's history series, all aligned to the parsed ``time`` axis.
+
+    Raises
+    ------
+    TraceReadError
+        If the file is missing/unreadable/empty, lacks the ``time`` column, or
+        is missing any expected series column (AC #6).
+    """
+    path = os.fspath(path)
+
+    if not os.path.isfile(path):
+        raise TraceReadError("Trace file does not exist: {}".format(path))
+
+    try:
+        df = pd.read_csv(path, sep="\t")
+    except pd.errors.EmptyDataError as e:
+        raise TraceReadError("Trace file is empty: {}".format(path)) from e
+    except Exception as e:  # unreadable/malformed -- surface, never swallow
+        raise TraceReadError(
+            "Could not read trace file {}: {}".format(path, e)
+        ) from e
+
+    if df.empty:
+        raise TraceReadError("Trace file has no data rows: {}".format(path))
+
+    if TIME_COLUMN not in df.columns:
+        raise TraceReadError(
+            "Trace file {} is missing the required '{}' column".format(
+                path, TIME_COLUMN
+            )
+        )
+
+    missing = [
+        column
+        for column in FIELD_TO_COLUMN.values()
+        if column not in df.columns
+    ]
+    if missing:
+        raise TraceReadError(
+            "Trace file {} is missing expected columns: {}".format(
+                path, ", ".join(missing)
+            )
+        )
+
+    # Parse the time axis and align every series to it. errors="raise" so a
+    # non-datetime time column fails explicitly rather than silently.
+    try:
+        time_index = pd.DatetimeIndex(pd.to_datetime(df[TIME_COLUMN]))
+    except Exception as e:
+        raise TraceReadError(
+            "Trace file {} has an unparseable '{}' column: {}".format(
+                path, TIME_COLUMN, e
+            )
+        ) from e
+    time_index.name = TIME_COLUMN
+
+    # Column selection into aligned series -- no fillna/forward-fill, so empty
+    # cells remain NaN (AC #4). sim_id is a convenience derived from the stem.
+    series = {
+        field: pd.Series(
+            df[column].to_numpy(), index=time_index, name=field
+        )
+        for field, column in FIELD_TO_COLUMN.items()
+    }
+    sim_id = os.path.splitext(os.path.basename(path))[0]
+
+    return SimulationTrace(sim_id=sim_id, time=time_index, **series)
+
+
+# Field-name/dataclass consistency guard: the only non-series fields are
+# ``sim_id`` and ``time``; every other SimulationTrace field must have a
+# column mapping. Fails loudly at import if the two drift out of sync.
+_series_fields = {f.name for f in fields(SimulationTrace)} - {"sim_id", "time"}
+assert _series_fields == set(FIELD_TO_COLUMN), (
+    "SimulationTrace series fields and FIELD_TO_COLUMN are out of sync: "
+    "{}".format(_series_fields.symmetric_difference(set(FIELD_TO_COLUMN)))
+)


### PR DESCRIPTION
## TRSET-21 — Trace-tier reader (contract/data layer)

Ticket: [TRSET-21](https://tidepool.atlassian.net/browse/TRSET-21) · Parent: TRSET-6 · Consumed by TRSET-22 (renderer), TRSET-23 (Streamlit).

### Summary
Adds a pure, testable trace-tier reader that parses a single simulator run's `<sim_id>.tsv` into a typed `SimulationTrace` exposing the history series that back a Loop-home-screen-style visualization: true/sensor BG, IOB, basal, boluses, carbs, and COB. No plotting, no Streamlit, no file writes.

### What landed (all additive — no existing code modified)
- `tidepool_data_science_simulator/trace/reader.py` — `read_trace(path) -> SimulationTrace`, frozen dataclass, and `TraceReadError(ValueError)`.
- `tidepool_data_science_simulator/trace/__init__.py` — package API.
- `tests/test_trace_reader.py` — 13 isolation unit tests.
- `tests/test_trace_reader_integration.py` — 6 end-to-end tests against a real `TLR-000-swift` `loop_risk_v2_0` run + the real Swift dylib.

### Behavior (acceptance criteria)
- Reads tab-separated; parses `time` to datetime as the shared axis; all series align to it.
- Selects the series columns **by name** — tolerates the variable trailing `loop_prediction_abs_error_*` columns.
- Empty cells preserved as `NaN` — never fabricated or forward-filled. `loop_cob` may be sparse or entirely empty (non-active-Loop stages) and is tolerated.
- **No** prediction/forecast field exposed (the TSV stores only a per-timestamp scalar endpoint, not a forecast series).
- Explicit, informative `TraceReadError` for empty/unreadable files, missing `time`, or any missing expected column — no silent failures.
- Pure data layer: no matplotlib, no Streamlit, no file writes. Read-only consumer of the `get_results_df()` / `save_df()` TSV contract.

### Tests
- Unit: `13 passed`.
- Integration: `6 passed` against the real dylib (asserts each trace series matches the on-disk `.tsv` at the boundary; skips cleanly when the dylib is unavailable).

### Notes
- **Change type:** Feature · **Regression risk:** Low (isolated new module, no shared state) · **Breaking change:** No.
- **README intentionally omitted** at requester's direction (the one skipped Definition-of-Done item).
- **Follow-up flagged (out of scope):** a forward-projecting forecast curve is not reconstructable from current output — the TSV stores only `loop_final_glucose_pred` (last forecast value per step), not the full array. Exposing it needs a source-data change to persist `predicted_glucose_values`; that's its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TRSET-21]: https://tidepool.atlassian.net/browse/TRSET-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ