### PR TITLE
[feature] TRSET-23: expose per-sim trace paths on RiskDirRunResult

### DIFF
--- a/tests/test_gui_runner.py
+++ b/tests/test_gui_runner.py
@@ -259,3 +259,88 @@ def test_target_risk_dir_passed_through_to_generator(run_env, monkeypatch):
     gui_runner.run_risk_assessment("unused_config_dir", target_risk_dir="TLR-HF")
 
     assert captured_kwargs["target_risk_dir"] == "TLR-HF"
+
+
+# ---------------------------------------------------------------------------
+# trace_paths (TRSET-23)
+# ---------------------------------------------------------------------------
+
+def test_trace_paths_grouped_by_scenario_file_and_keyed_by_sim_id(run_env, monkeypatch):
+    """Each scenario config file maps to {sim_id: <save_dir>/<risk_dir>/<sim_id>.tsv}.
+
+    The mapping is derived from run_simulations' own full_results dict, so the
+    sim_ids are exactly the ones that ran (and that save_df wrote a .tsv for).
+    """
+    save_dir, monkeypatch = run_env
+
+    sims_by_scenario = {
+        "Simulation-Configuration-TLR-1_Adolescent_profile.json": {
+            "pre-Loop_NoMitigations_t1_adolescent": None,
+            "pre-noLoop_t1_adolescent": None,
+        },
+        "Simulation-Configuration-TLR-1_Median_profile.json": {
+            "pre-Loop_NoMitigations_t1_median": None,
+        },
+    }
+    generator_items = [("TLR-1", name, _fake_sim_suite()) for name in sims_by_scenario]
+    monkeypatch.setattr(gui_runner, "build_risk_sim_generator", lambda *a, **kw: iter(generator_items))
+    monkeypatch.setattr(gui_runner, "_list_target_risk_dirs", lambda *a, **kw: ["TLR-1"])
+    monkeypatch.setattr(gui_runner, "build_assessment", lambda tlr_dir, timestamp: SimpleNamespace())
+    monkeypatch.setattr(
+        gui_runner, "run_simulations",
+        lambda sims, **kw: (sims_by_scenario[kw["name"]], None),
+    )
+
+    result = gui_runner.run_risk_assessment("unused_config_dir")
+
+    trace_paths = result.risk_dir_results[0].trace_paths
+    assert set(trace_paths) == set(sims_by_scenario)
+    risk_dir_path = os.path.join(save_dir, "TLR-1")
+    for scenario_name, sim_ids in sims_by_scenario.items():
+        assert trace_paths[scenario_name] == {
+            sim_id: os.path.join(risk_dir_path, f"{sim_id}.tsv") for sim_id in sim_ids
+        }
+
+
+def test_trace_paths_are_reset_between_risk_dirs(run_env, monkeypatch):
+    """A second TLR dir must not inherit the first one's trace paths -- the same
+    per-dir reset png_paths gets."""
+    save_dir, monkeypatch = run_env
+
+    per_scenario_sims = {
+        "scenario_a.json": {"pre-Loop_NoMitigations_t1_median": None},
+        "scenario_b.json": {"pre-noLoop_t1_median": None},
+    }
+    generator_items = [
+        ("TLR-1", "scenario_a.json", _fake_sim_suite()),
+        ("TLR-2", "scenario_b.json", _fake_sim_suite()),
+    ]
+    monkeypatch.setattr(gui_runner, "build_risk_sim_generator", lambda *a, **kw: iter(generator_items))
+    monkeypatch.setattr(gui_runner, "_list_target_risk_dirs", lambda *a, **kw: ["TLR-1", "TLR-2"])
+    monkeypatch.setattr(gui_runner, "build_assessment", lambda tlr_dir, timestamp: SimpleNamespace())
+    monkeypatch.setattr(
+        gui_runner, "run_simulations",
+        lambda sims, **kw: (per_scenario_sims[kw["name"]], None),
+    )
+
+    result = gui_runner.run_risk_assessment("unused_config_dir")
+
+    first, second = result.risk_dir_results
+    assert list(first.trace_paths) == ["scenario_a.json"]
+    assert list(second.trace_paths) == ["scenario_b.json"]
+    # Each dir's paths point into its own results dir.
+    assert os.path.dirname(first.trace_paths["scenario_a.json"]["pre-Loop_NoMitigations_t1_median"]) == \
+        os.path.join(save_dir, "TLR-1")
+    assert os.path.dirname(second.trace_paths["scenario_b.json"]["pre-noLoop_t1_median"]) == \
+        os.path.join(save_dir, "TLR-2")
+
+
+def test_stage_identity_helpers_are_reexported_for_gui_consumers():
+    """TRSET-23: the GUI reads stage identity through this entry point rather
+    than replicating the post_processing/ sys.path setup. severity_model stays
+    the single source of truth -- these are re-exports, not redefinitions."""
+    import severity_model
+
+    assert gui_runner.classify_sim_id is severity_model.classify_sim_id
+    assert gui_runner.STAGE_ORDER is severity_model.STAGE_ORDER
+    assert gui_runner.STAGE_DISPLAY is severity_model.STAGE_DISPLAY

--- a/tidepool_data_science_simulator/projects/risk/gui_runner.py
+++ b/tidepool_data_science_simulator/projects/risk/gui_runner.py
@@ -41,6 +41,17 @@ if _POST_PROCESSING_DIR not in sys.path:
     sys.path.insert(0, _POST_PROCESSING_DIR)
 
 from severity_model import build_assessment, SeverityAssessment  # noqa: E402
+# Re-exported for GUI consumers (TRSET-23). severity_model remains the single
+# source of truth for stage identity; it lives in the simulator's top-level
+# post_processing/ dir, which is NOT part of the installed package and is only
+# importable after the sys.path insert above. Re-exporting here keeps consumers
+# on this module -- the single validated entry point per this file's docstring --
+# instead of each of them replicating that path setup.
+from severity_model import (  # noqa: E402,F401
+    classify_sim_id,
+    STAGE_DISPLAY,
+    STAGE_ORDER,
+)
 
 
 @dataclass
@@ -55,10 +66,20 @@ class ConfigValidationResult:
 class RiskDirRunResult:
     """Outcome for one TLR-* directory. assessment is None when build_assessment
     found no usable data for it -- surfaced explicitly, never silently dropped.
-    png_paths has one entry per scenario config file run in this directory."""
+    png_paths has one entry per scenario config file run in this directory.
+
+    trace_paths (TRSET-23) exposes each completed sim's per-run ``<sim_id>.tsv``
+    so consumers can read it with ``trace.read_trace``. It is keyed
+    scenario_config_filename -> {sim_id: tsv_path}: one scenario config file is
+    one VP profile, and its sim_ids are that profile's stages, so the nesting is
+    the (profile, stage) grouping consumers need. Paths are the ones
+    run_simulations(save_results=True) writes via utils.save_df; existence is not
+    re-probed here, so a consumer that cannot read one should surface that
+    explicitly rather than treat it as absent."""
     risk_dir_name: str
     assessment: Optional[SeverityAssessment]
     png_paths: list = field(default_factory=list)
+    trace_paths: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -145,12 +166,15 @@ def run_risk_assessment(
     completed_count = 0
     previous_risk_dir_name = None
     current_png_paths = []
+    current_trace_paths = {}
 
-    def _finalize(risk_dir_name, png_paths):
+    def _finalize(risk_dir_name, png_paths, trace_paths):
         nonlocal completed_count
         risk_result_dirpath = os.path.join(save_dir, risk_dir_name)
         assessment = build_assessment(risk_result_dirpath, timestamp)
-        risk_dir_results.append(RiskDirRunResult(risk_dir_name, assessment, png_paths))
+        risk_dir_results.append(
+            RiskDirRunResult(risk_dir_name, assessment, png_paths, trace_paths)
+        )
         completed_count += 1
         if progress_callback is not None:
             progress_callback(completed_count, total, risk_dir_name)
@@ -164,8 +188,9 @@ def run_risk_assessment(
             # Finalize the just-completed dir BEFORE checking cancellation --
             # otherwise a cancel landing exactly on this transition would
             # silently drop a risk dir that had already fully finished.
-            _finalize(previous_risk_dir_name, current_png_paths)
+            _finalize(previous_risk_dir_name, current_png_paths, current_trace_paths)
             current_png_paths = []
+            current_trace_paths = {}
 
         if cancel_event is not None and cancel_event.is_set():
             return RunResult(save_dir=save_dir, risk_dir_results=risk_dir_results, cancelled=True)
@@ -193,9 +218,17 @@ def run_risk_assessment(
         plot_sim_results(full_results_dict, save=True, save_path=figure_filepath)
         current_png_paths.append(figure_filepath)
 
+        # Per-sim trace paths (TRSET-23). save_df names each file "<sim_id>.tsv"
+        # under save_dir, and full_results_dict is keyed by the same sim_ids, so
+        # the mapping is derived from what actually ran -- no directory globbing.
+        current_trace_paths[scenario_json_name] = {
+            sim_id: os.path.join(risk_result_dirpath, f"{sim_id}.tsv")
+            for sim_id in full_results_dict
+        }
+
         previous_risk_dir_name = risk_dir_name
 
     if previous_risk_dir_name is not None:
-        _finalize(previous_risk_dir_name, current_png_paths)
+        _finalize(previous_risk_dir_name, current_png_paths, current_trace_paths)
 
     return RunResult(save_dir=save_dir, risk_dir_results=risk_dir_results, cancelled=False)


### PR DESCRIPTION
Additive `gui_runner` support for the GUI's TRSET-23 Loop-home chart wiring. Paired with loop-risk-simulator-gui `sf/trset-23-streamlit-integration`.

Ticket: [TRSET-23](https://tidepool.atlassian.net/browse/TRSET-23) (parent TRSET-6)

## What changed

- **`RiskDirRunResult.trace_paths`** (new, additive, appended last so positional constructors keep working): `scenario_config_filename -> {sim_id: <run_dir>/<sim_id>.tsv}`. One scenario config file is one VP profile and its `sim_id`s are that profile's stages, so the nesting is exactly the `(profile, stage)` grouping the GUI needs.
  - Derived from `run_simulations`' own `full_results` keys — the sims that actually ran, and the same ids `utils.save_df` names each `.tsv` after — rather than globbing the run directory.
  - Reset per TLR directory, exactly like `png_paths`.
  - Existence is not re-probed: a consumer that cannot read a path should surface that explicitly rather than treat it as an absent stage.
- **Re-export `classify_sim_id` / `STAGE_ORDER` / `STAGE_DISPLAY`** from `severity_model`, so consumers read stage identity through this module — the single validated entry point per its own docstring — instead of each replicating the `post_processing/` `sys.path` insert that makes it importable. These are re-exports, not redefinitions; `severity_model` remains the single source of truth and is not modified.

Nothing else changes: no existing field, signature, schema, or behavior. `run_risk_assessment`'s contract is unchanged, and `png_paths` / `plot_sim_results` are untouched.

## Change type / risk

**Feature** (additive). Regression risk **Medium** — `gui_runner` is a shared entry point — contained by the change being additive-only. **Not a breaking change**, so no migration guidance or rollback note applies.

## Validation

3 tests added to `tests/test_gui_runner.py`: the grouping/keying from a populated `run_simulations` result, the per-TLR-directory reset, and that the stage helpers are the same objects as `severity_model`'s. **`test_gui_runner` 13/13 pass.**

Full suite: 525 passed / 31 failed / 5 skipped. All 31 failures are pre-existing and unrelated — 13 in `tests/test_validate_configs_integration.py` reproduce identically on a clean `origin/main` worktree, and the other 18 live in four files that are untracked local scratch, not part of this repo.

The end-to-end exercise of this field against a real simulation run lives in the paired GUI PR's integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TRSET-23]: https://tidepool.atlassian.net/browse/TRSET-23?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ