### PR TITLE
[feature] TRSET-7: write metadata.json at run time, re-export the RTF renderer

### DIFF
--- a/tests/test_gui_runner.py
+++ b/tests/test_gui_runner.py
@@ -9,6 +9,7 @@ gui_runner's own orchestration logic (finalize-once-per-TLR-dir, progress
 reporting, cancellation, validation gating) in isolation.
 """
 
+import json
 import os
 import shutil
 import tempfile
@@ -344,3 +345,66 @@ def test_stage_identity_helpers_are_reexported_for_gui_consumers():
     assert gui_runner.classify_sim_id is severity_model.classify_sim_id
     assert gui_runner.STAGE_ORDER is severity_model.STAGE_ORDER
     assert gui_runner.STAGE_DISPLAY is severity_model.STAGE_DISPLAY
+
+
+# ---------------------------------------------------------------------------
+# metadata.json (TRSET-7)
+# ---------------------------------------------------------------------------
+
+def test_run_writes_metadata_json_with_the_assessment_timestamp(run_env, monkeypatch):
+    """The run's save_dir carries metadata.json in the shape (and with the
+    timestamp) create_severity_summary reads, so the directory is a valid input
+    to it -- here and via the existing CLI."""
+    save_dir, monkeypatch = run_env
+
+    assessment_timestamps = []
+    monkeypatch.setattr(gui_runner, "build_risk_sim_generator",
+                        lambda *a, **kw: iter([("TLR-1", "scenario_a.json", _fake_sim_suite())]))
+    monkeypatch.setattr(gui_runner, "_list_target_risk_dirs", lambda *a, **kw: ["TLR-1"])
+    monkeypatch.setattr(
+        gui_runner, "build_assessment",
+        lambda tlr_dir, timestamp: assessment_timestamps.append(timestamp) or SimpleNamespace(),
+    )
+
+    gui_runner.run_risk_assessment("unused_config_dir")
+
+    metadata_path = os.path.join(save_dir, gui_runner.METADATA_FILENAME)
+    assert os.path.isfile(metadata_path), "run did not write metadata.json"
+    with open(metadata_path) as metadata_file:
+        metadata = json.load(metadata_file)
+    # Same key create_severity_summary reads, same value the assessments are
+    # dated with -- an exported summary matches what the GUI displayed.
+    assert metadata == {"timestamp": "2026-07-21T00:00:00"}
+    assert assessment_timestamps == ["2026-07-21T00:00:00"]
+
+
+def test_metadata_json_is_written_before_any_simulation_runs(run_env, monkeypatch):
+    """Written up front, off the run's own save_dir/timestamp -- not appended at
+    the end, so a cancelled run still exports."""
+    save_dir, monkeypatch = run_env
+    metadata_path = os.path.join(save_dir, gui_runner.METADATA_FILENAME)
+
+    seen_during_run = []
+
+    def _observing_run_simulations(sims, **kwargs):
+        seen_during_run.append(os.path.isfile(metadata_path))
+        return {}, None
+
+    monkeypatch.setattr(gui_runner, "build_risk_sim_generator",
+                        lambda *a, **kw: iter([("TLR-1", "scenario_a.json", _fake_sim_suite())]))
+    monkeypatch.setattr(gui_runner, "_list_target_risk_dirs", lambda *a, **kw: ["TLR-1"])
+    monkeypatch.setattr(gui_runner, "build_assessment", lambda tlr_dir, timestamp: SimpleNamespace())
+    monkeypatch.setattr(gui_runner, "run_simulations", _observing_run_simulations)
+
+    gui_runner.run_risk_assessment("unused_config_dir")
+
+    assert seen_during_run == [True]
+
+
+def test_severity_summary_renderer_is_reexported_for_gui_consumers():
+    """TRSET-7: the GUI writes the RTF summaries through this entry point, same
+    seam as the stage-identity re-exports. A re-export, not a wrapper -- the RTF
+    output stays byte-identical to the CLI's."""
+    import create_severity_summary
+
+    assert gui_runner.process_results_directory is create_severity_summary.process_results_directory

--- a/tidepool_data_science_simulator/projects/risk/gui_runner.py
+++ b/tidepool_data_science_simulator/projects/risk/gui_runner.py
@@ -11,6 +11,7 @@ future "configure parameters directly" mode can hand this module a
 freshly-written temp directory with no changes required here.
 """
 
+import json
 import os
 import sys
 import threading
@@ -52,6 +53,19 @@ from severity_model import (  # noqa: E402,F401
     STAGE_DISPLAY,
     STAGE_ORDER,
 )
+# Also re-exported for GUI consumers (TRSET-7): the RTF renderer's directory
+# entry point. Same reasoning as the stage-identity re-exports above -- it lives
+# in that same non-packaged post_processing/ dir, so consumers reach it here
+# rather than replicating the sys.path insert. Used as-is; its RTF output is
+# untouched, so an exported summary is byte-identical to the CLI's.
+from create_severity_summary import process_results_directory  # noqa: E402,F401
+
+
+# Written into save_dir at run time so a GUI run directory is a valid input to
+# create_severity_summary (which reads its run timestamp from this file, and
+# otherwise refuses the directory). Same filename and same {"timestamp": ...}
+# shape loop_risk_v2_0's __main__ writes, so the CLI path is unchanged.
+METADATA_FILENAME = "metadata.json"
 
 
 @dataclass
@@ -137,6 +151,18 @@ def validate_config_dir(config_dir: str, target_risk_dir: Optional[str] = None) 
     return ConfigValidationResult(is_valid, errors_by_file, warnings_by_file)
 
 
+def _write_run_metadata(save_dir: str, timestamp: str) -> str:
+    """Write ``{"timestamp": ...}`` to save_dir/metadata.json; return its path.
+
+    Carries the same timestamp the run hands to ``build_assessment``, so an
+    exported summary is dated identically to the assessment the GUI displays.
+    """
+    metadata_path = os.path.join(save_dir, METADATA_FILENAME)
+    with open(metadata_path, "w") as metadata_file:
+        json.dump({"timestamp": timestamp}, metadata_file, indent=4)
+    return metadata_path
+
+
 def run_risk_assessment(
     config_dir: str,
     target_risk_dir: Optional[str] = None,
@@ -146,6 +172,9 @@ def run_risk_assessment(
     """
     Run a risk assessment over every TLR-* directory in config_dir (or just
     target_risk_dir, if given), returning one RiskDirRunResult per directory.
+
+    Writes ``metadata.json`` into the run's save_dir (TRSET-7) so the directory
+    is a valid input to create_severity_summary, on this path and via the CLI.
 
     Raises ValueError if any in-scope config file has validation errors --
     callers should still call validate_config_dir directly to surface errors
@@ -160,6 +189,7 @@ def run_risk_assessment(
 
     save_dir = create_save_dir()
     timestamp = get_timestamp()
+    _write_run_metadata(save_dir, timestamp)
     total = len(_list_target_risk_dirs(config_dir, target_risk_dir))
 
     risk_dir_results = []


### PR DESCRIPTION
Additive simulator-side support for the GUI's TRSET-7 exportable-results feature ([TRSET-7](https://tidepool.atlassian.net/browse/TRSET-7)). **Merge this before the GUI PR** — the GUI consumes both additions.

## What changed

- **`run_risk_assessment` writes `save_dir/metadata.json`** as `{"timestamp": <run timestamp>}`, immediately after creating the run directory. Same filename and shape `loop_risk_v2_0.__main__` already writes. `create_severity_summary` reads its run timestamp from that file and otherwise refuses the directory, so this is what makes a GUI run directory a valid input to it — both on the new export path and via the existing CLI. The timestamp is the one already handed to `build_assessment`, so an exported summary is dated like the assessment the GUI displayed. Written up front rather than at the end, so a cancelled run stays exportable.
- **`create_severity_summary.process_results_directory` is re-exported** for GUI consumers — the same seam, for the same reason, as TRSET-23's `classify_sim_id` / `STAGE_ORDER` / `STAGE_DISPLAY` re-exports: it lives in the non-packaged top-level `post_processing/` dir that only this module's `sys.path` insert makes importable. A re-export, not a wrapper, so RTF output stays byte-identical to the CLI's.

Nothing existing changes: no dataclass field, signature, schema, or RTF byte. `RunResult` / `RiskDirRunResult` shapes are untouched.

## Validation

- 3 tests added: metadata contents/timestamp, written-before-any-simulation, re-export identity.
- `tests/test_gui_runner.py` **16/16**. `post_processing/test_create_severity_summary.py` **32/32**, unchanged.
- Full suite **539 passed / 31 failed / 5 skipped** — all 31 are the documented pre-existing set (13 in `test_validate_configs_integration.py`, 18 in four untracked local scratch files); none touch `gui_runner` or the RTF renderer.

Consumer PR: tidepool-org/loop-risk-simulator-gui#13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TRSET-7]: https://tidepool.atlassian.net/browse/TRSET-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ