### PR TITLE
[bugfix] TRSET-27: make create_severity_summary fail loudly instead of silently

### DIFF
--- a/post_processing/README_create_severity_summary.md
+++ b/post_processing/README_create_severity_summary.md
@@ -1,0 +1,82 @@
+# Risk Severity Summary Generator — failure contract
+
+## Description
+
+`create_severity_summary.py` renders the `risk_summary_<sim_id>.rtf` documents for
+a risk-run results directory. **Bugfix:** `process_results_directory()` used to
+print a diagnostic and return `None` on every failure path, so no caller could
+tell a no-op run from a successful one, and the CLI printed `Done!` and exited
+`0` regardless. It now **raises `SeveritySummaryError`** when a directory cannot
+be summarized at all, **returns a `SummaryResult`** naming what it wrote and
+which directories it skipped, only treats `TLR-*` **directories** (sorted) as run
+directories, and never dates a summary with the placeholder `"Unknown"`.
+
+## Example usage
+
+```bash
+# Exits 0 only if at least one summary document was written.
+python create_severity_summary.py /path/to/Risk_Run_<timestamp>
+```
+
+Programmatic use:
+
+```python
+from create_severity_summary import SeveritySummaryError, process_results_directory
+
+try:
+    result = process_results_directory(save_dir)
+except SeveritySummaryError as exc:
+    ...                                  # unusable directory: report, don't proceed
+for tlr_dir, reason in result.skipped:   # legitimate partial outcome
+    print(f"no summary for {tlr_dir}: {reason}")
+print(f"wrote {len(result.written)} summaries")
+```
+
+### What raises vs. what is reported
+
+| Condition | Before | Now |
+|---|---|---|
+| `metadata.json` missing | print + return `None` | raises `SeveritySummaryError` |
+| `metadata.json` unparseable | raw `JSONDecodeError` | raises `SeveritySummaryError` |
+| no `timestamp` / `run_timestamp` key | summary dated `"Unknown"` | raises `SeveritySummaryError` |
+| no `TLR-*` subdirectories | print + return `None` | raises `SeveritySummaryError` |
+| one `TLR-*` dir yields no assessment | bare `continue` | reported in `result.skipped` |
+| stray file named `TLR-*.txt` | passed to `build_assessment` | ignored (directories only) |
+| nothing written | CLI prints `Done!`, exits `0` | CLI exits `1` |
+
+A single `TLR-*` directory with no usable data stays a *partial outcome*, not an
+error — a real run can legitimately contain one, and the GUI already renders that
+state — so it is reported rather than raised.
+
+## Validation
+
+17 tests added (`test_create_severity_summary.py`): each raising condition, the
+`run_timestamp` fallback key still being honored, per-directory skips, mixed
+runs, sorted processing order, the stray-`TLR-*`-file case, and all four CLI exit
+codes. One test asserts the written RTF is **byte-identical** to `render_rtf`'s
+output, alongside the pre-existing 32-test renderer suite — RTF bytes are
+unchanged. Full suite: 556 passed / 31 failed / 5 skipped, the 31 being the
+documented pre-existing set (13 in `test_validate_configs_integration.py`, 18 in
+untracked local scratch files). The GUI's suite is unaffected: 138 passed / 7
+skipped.
+
+## Cautions / limitations
+
+**Behavior change, not a signature change — migration:** any caller that relied
+on `process_results_directory` returning quietly on a bad directory must now
+catch `SeveritySummaryError`. The two in-repo callers are handled: the CLI
+converts it to exit code `1`, and the GUI's export path
+(`loop-risk-simulator-gui/export_bundle.py`) pre-checks both fatal conditions
+itself and surfaces any exception as an error in the UI. Ad-hoc scripts outside
+these repos may need the `try`/`except` shown above.
+
+`gui_runner.METADATA_FILENAME` is now imported from this module rather than
+re-declared, so the writer and reader of `metadata.json` cannot drift apart; the
+constant is still importable from `gui_runner` for consumers.
+
+Regression risk **Medium** — shared post-processing entry point used by both the
+CLI and the GUI export — contained by RTF output being byte-identical and the
+change touching only orchestration. Not a breaking change to any signature or
+schema, so no migration of stored data applies; a revert is a single-commit
+revert of this change. `create_severity_summary_ORIGINAL.py` retains the old
+behavior and is deliberately untouched (legacy reference copy).

--- a/post_processing/create_severity_summary.py
+++ b/post_processing/create_severity_summary.py
@@ -15,11 +15,17 @@ inline.
 Backwards compatibility: round_half_up and calculate_integer_averages are
 re-exported from severity_model so the existing test_create_severity_summary.py
 imports continue to resolve unchanged.
+
+Failure contract: process_results_directory raises SeveritySummaryError when a
+results directory cannot be summarized at all, and returns a SummaryResult
+naming what it wrote and what it skipped. It previously printed and returned
+None on both, so neither the CLI nor the GUI export could tell a no-op run from
+a successful one.
 """
 
 import os
 import json
-import glob
+from dataclasses import dataclass, field
 
 from severity_model import (
     build_assessment,
@@ -224,29 +230,106 @@ Auto-generated output from Tidepool Risk Severity Evaluation Simulator Tool
 # Directory processing (orchestration + file writing)
 # =============================================================================
 
-def process_results_directory(results_dir):
-    """Process a results directory: build each TLR's assessment and write its RTF."""
-    metadata_path = os.path.join(results_dir, 'metadata.json')
+METADATA_FILENAME = 'metadata.json'
+TLR_DIR_PREFIX = 'TLR-'
+# The keys a run's metadata.json may carry its run timestamp under. Read in this
+# order; absent both, the run cannot be dated and is an error rather than a
+# summary stamped with a placeholder.
+_TIMESTAMP_KEYS = ('timestamp', 'run_timestamp')
+
+
+class SeveritySummaryError(Exception):
+    """A results directory cannot be summarized at all.
+
+    Raised instead of printing and returning, so a caller (the CLI, the GUI
+    export) can tell an unusable directory from a successful run. A single TLR
+    directory with no usable data is NOT this -- that is a partial outcome,
+    reported in SummaryResult.skipped.
+    """
+
+
+@dataclass
+class SummaryResult:
+    """What process_results_directory actually did.
+
+    written: the RTF paths it wrote, one per TLR directory that produced an
+    assessment. skipped: ``(tlr_dir, reason)`` for each directory that did not,
+    so a caller can report them rather than silently shipping fewer summaries
+    than there were directories.
+    """
+    written: list = field(default_factory=list)
+    skipped: list = field(default_factory=list)
+
+
+def _read_run_timestamp(results_dir):
+    """The run timestamp from results_dir/metadata.json.
+
+    Raises SeveritySummaryError if the file is missing, unreadable, or carries no
+    recognized timestamp key -- every summary is dated from this, so a placeholder
+    would silently put "Unknown" on a regulatory document.
+    """
+    metadata_path = os.path.join(results_dir, METADATA_FILENAME)
     if not os.path.exists(metadata_path):
-        print(f"Error: metadata.json not found in {results_dir}")
-        return
+        raise SeveritySummaryError(
+            f"{METADATA_FILENAME} not found in {results_dir}: the run cannot be dated. "
+            "A GUI run writes it automatically; for a CLI run, check that this is a "
+            "run directory produced by loop_risk_v2_0."
+        )
+    try:
+        with open(metadata_path, 'r') as f:
+            metadata = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        raise SeveritySummaryError(f"Could not read {metadata_path}: {exc}") from exc
 
-    with open(metadata_path, 'r') as f:
-        metadata = json.load(f)
-    timestamp = metadata.get('timestamp', metadata.get('run_timestamp', 'Unknown'))
+    for key in _TIMESTAMP_KEYS:
+        if metadata.get(key):
+            return metadata[key]
+    raise SeveritySummaryError(
+        f"{metadata_path} carries none of {list(_TIMESTAMP_KEYS)}, so the run cannot be dated."
+    )
 
-    tlr_dirs = glob.glob(os.path.join(results_dir, 'TLR-*'))
+
+def _find_tlr_dirs(results_dir):
+    """The TLR-* subdirectories of results_dir, sorted.
+
+    Directories only -- a file named e.g. TLR-notes.txt is not a run directory and
+    must not be handed to build_assessment. Sorted so processing order (and so the
+    reported order) is the same on every machine.
+    """
+    return sorted(
+        os.path.join(results_dir, name)
+        for name in os.listdir(results_dir)
+        if name.startswith(TLR_DIR_PREFIX) and os.path.isdir(os.path.join(results_dir, name))
+    )
+
+
+def process_results_directory(results_dir):
+    """Build each TLR directory's assessment and write its RTF; return a SummaryResult.
+
+    Raises SeveritySummaryError if the directory cannot be summarized at all --
+    unreadable/undated metadata.json, or no TLR-* subdirectory. A single TLR
+    directory that yields no assessment is recorded in the result's ``skipped``
+    list instead, since a run legitimately can contain one.
+    """
+    timestamp = _read_run_timestamp(results_dir)
+
+    tlr_dirs = _find_tlr_dirs(results_dir)
     if not tlr_dirs:
-        print(f"No TLR-* subdirectories found in {results_dir}")
-        return
+        raise SeveritySummaryError(
+            f"No {TLR_DIR_PREFIX}* subdirectories found in {results_dir}: nothing to summarize."
+        )
 
     print(f"Found {len(tlr_dirs)} TLR subdirectories")
+    result = SummaryResult()
 
     for tlr_dir in tlr_dirs:
         print(f"\nProcessing: {tlr_dir}")
 
         assessment = build_assessment(tlr_dir, timestamp)
         if assessment is None:
+            reason = "no usable summary results data"
+            print(f"  Skipped: {reason}")
+            result.skipped.append((tlr_dir, reason))
             continue
 
         print(f"  Simulation ID: {assessment.simulation_id}")
@@ -266,7 +349,10 @@ def process_results_directory(results_dir):
         output_path = os.path.join(tlr_dir, f"risk_summary_{assessment.simulation_id}.rtf")
         with open(output_path, 'w') as f:
             f.write(rtf)
+        result.written.append(output_path)
         print(f"Created shell document: {output_path}")
+
+    return result
 
 
 def main():
@@ -282,8 +368,21 @@ def main():
         print(f"Error: Directory not found: {args.results_dir}")
         return 1
 
-    process_results_directory(args.results_dir)
-    print("\nDone!")
+    try:
+        result = process_results_directory(args.results_dir)
+    except SeveritySummaryError as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    for tlr_dir, reason in result.skipped:
+        print(f"Skipped {tlr_dir}: {reason}")
+    print(f"\nWrote {len(result.written)} summary document(s); "
+          f"skipped {len(result.skipped)} directory(ies).")
+    # An invocation that produced no document is not a success, whatever the
+    # per-directory reasons were -- callers (and CI) read this exit code.
+    if not result.written:
+        print("Error: no summary documents were written.")
+        return 1
     return 0
 
 

--- a/post_processing/test_create_severity_summary.py
+++ b/post_processing/test_create_severity_summary.py
@@ -6,6 +6,8 @@ Covers:
     (round-half-up) rounding behavior for risk severity scores.
   - render_rtf()'s results table -- column order/count and the LBGI/DKAI
     columns, driven by a real build_assessment() over temp summary CSVs.
+  - process_results_directory()'s failure contract -- what raises, what is
+    reported as a skipped directory, and what it returns.
 """
 
 import pytest
@@ -16,8 +18,12 @@ import os
 sys.path.insert(0, os.path.dirname(__file__))
 
 from create_severity_summary import (
+    METADATA_FILENAME,
+    SeveritySummaryError,
+    SummaryResult,
     TABLE_CELL_STOPS,
     calculate_integer_averages,
+    process_results_directory,
     render_rtf,
     round_half_up,
 )
@@ -276,3 +282,191 @@ class TestRenderRtfTableValues:
         for row in rows[1:]:
             assert row[lbgi_index] == "NA"
             assert row[dkai_index] == "NA"
+
+
+# =============================================================================
+# process_results_directory() failure contract
+# =============================================================================
+
+# Every path through this function used to print a diagnostic and return None,
+# so a caller could not distinguish "wrote three summaries" from "wrote nothing".
+# These tests pin the replacement: raise when the directory is unusable, report
+# a per-directory skip, and return what was actually done.
+
+import json  # noqa: E402
+
+from create_severity_summary import main  # noqa: E402
+
+_RUN_TIMESTAMP = "2026-08-06T09:15:00.123456"
+
+
+def _write_metadata(run_dir, payload={"timestamp": _RUN_TIMESTAMP}):
+    path = os.path.join(run_dir, METADATA_FILENAME)
+    with open(path, "w") as fh:
+        json.dump(payload, fh)
+    return path
+
+
+def _usable_tlr_dir(run_dir, name="TLR-999-test"):
+    """A TLR directory with the real summary CSVs build_assessment needs."""
+    tlr_dir = os.path.join(run_dir, name)
+    os.makedirs(tlr_dir)
+    _write_summary_csv(tlr_dir, "median", _PROFILE_A_ROWS)
+    _write_summary_csv(tlr_dir, "adolescent", _PROFILE_B_ROWS)
+    return tlr_dir
+
+
+class TestProcessResultsDirectoryRaises:
+    """A results directory that cannot be summarized at all is an error."""
+
+    def test_missing_metadata_raises(self, tmp_path):
+        _usable_tlr_dir(str(tmp_path))
+
+        with pytest.raises(SeveritySummaryError, match=METADATA_FILENAME):
+            process_results_directory(str(tmp_path))
+
+    def test_unparseable_metadata_raises_rather_than_leaking_a_json_error(self, tmp_path):
+        with open(os.path.join(str(tmp_path), METADATA_FILENAME), "w") as fh:
+            fh.write("{not json")
+        _usable_tlr_dir(str(tmp_path))
+
+        with pytest.raises(SeveritySummaryError):
+            process_results_directory(str(tmp_path))
+
+    @pytest.mark.parametrize("payload", [{}, {"other_key": "x"}, {"timestamp": ""}])
+    def test_metadata_without_a_usable_timestamp_raises(self, tmp_path, payload):
+        """The old code fell back to the literal 'Unknown', which then rendered
+        into the summary's 'Date and time of simulation run' field."""
+        _write_metadata(str(tmp_path), payload)
+        _usable_tlr_dir(str(tmp_path))
+
+        with pytest.raises(SeveritySummaryError, match="cannot be dated"):
+            process_results_directory(str(tmp_path))
+
+    def test_run_timestamp_key_is_still_accepted(self, tmp_path):
+        """The alternate key the original code read is still honored."""
+        _write_metadata(str(tmp_path), {"run_timestamp": _RUN_TIMESTAMP})
+        _usable_tlr_dir(str(tmp_path))
+
+        result = process_results_directory(str(tmp_path))
+
+        assert len(result.written) == 1
+
+    def test_no_tlr_directories_raises(self, tmp_path):
+        _write_metadata(str(tmp_path))
+
+        with pytest.raises(SeveritySummaryError, match="TLR-"):
+            process_results_directory(str(tmp_path))
+
+    def test_a_file_named_like_a_tlr_dir_is_not_a_run_directory(self, tmp_path):
+        """glob matched files too, so a stray TLR-*.txt was handed to
+        build_assessment as though it were a run directory."""
+        _write_metadata(str(tmp_path))
+        with open(os.path.join(str(tmp_path), "TLR-notes.txt"), "w") as fh:
+            fh.write("scratch notes\n")
+
+        with pytest.raises(SeveritySummaryError, match="TLR-"):
+            process_results_directory(str(tmp_path))
+
+
+class TestProcessResultsDirectoryResult:
+    """What it returns, and what it reports rather than swallowing."""
+
+    def test_writes_one_rtf_per_usable_directory_and_returns_their_paths(self, tmp_path):
+        _write_metadata(str(tmp_path))
+        tlr_dir = _usable_tlr_dir(str(tmp_path))
+
+        result = process_results_directory(str(tmp_path))
+
+        assert isinstance(result, SummaryResult)
+        assert result.skipped == []
+        assert len(result.written) == 1
+        written = result.written[0]
+        assert os.path.dirname(written) == tlr_dir
+        assert os.path.basename(written).startswith("risk_summary_")
+        assert os.path.isfile(written), "returned a path it did not write"
+
+    def test_a_directory_with_no_usable_data_is_reported_not_swallowed(self, tmp_path):
+        """This is a legitimate partial outcome -- a real run can contain one --
+        so it is reported in `skipped`, not raised."""
+        _write_metadata(str(tmp_path))
+        empty_dir = os.path.join(str(tmp_path), "TLR-000-empty")
+        os.makedirs(empty_dir)
+
+        result = process_results_directory(str(tmp_path))
+
+        assert result.written == []
+        assert len(result.skipped) == 1
+        skipped_dir, reason = result.skipped[0]
+        assert skipped_dir == empty_dir
+        assert reason
+
+    def test_a_mixed_run_reports_both_halves(self, tmp_path):
+        _write_metadata(str(tmp_path))
+        usable = _usable_tlr_dir(str(tmp_path))
+        empty = os.path.join(str(tmp_path), "TLR-000-empty")
+        os.makedirs(empty)
+
+        result = process_results_directory(str(tmp_path))
+
+        assert [os.path.dirname(p) for p in result.written] == [usable]
+        assert [d for d, _ in result.skipped] == [empty]
+
+    def test_directories_are_processed_in_sorted_order(self, tmp_path):
+        """Order came from glob (arbitrary), so the same run reported differently
+        on different machines."""
+        _write_metadata(str(tmp_path))
+        for name in ("TLR-300-test", "TLR-100-test", "TLR-200-test"):
+            _usable_tlr_dir(str(tmp_path), name)
+
+        result = process_results_directory(str(tmp_path))
+
+        assert [os.path.basename(os.path.dirname(p)) for p in result.written] == [
+            "TLR-100-test", "TLR-200-test", "TLR-300-test",
+        ]
+
+
+class TestCliExitCodes:
+    """The CLI printed 'Done!' and exited 0 no matter what happened."""
+
+    def test_success_exits_zero(self, tmp_path, monkeypatch):
+        _write_metadata(str(tmp_path))
+        _usable_tlr_dir(str(tmp_path))
+        monkeypatch.setattr(sys, "argv", ["create_severity_summary.py", str(tmp_path)])
+
+        assert main() == 0
+
+    def test_unusable_directory_exits_nonzero(self, tmp_path, monkeypatch):
+        _usable_tlr_dir(str(tmp_path))  # no metadata.json
+        monkeypatch.setattr(sys, "argv", ["create_severity_summary.py", str(tmp_path)])
+
+        assert main() == 1
+
+    def test_writing_nothing_exits_nonzero_even_without_an_error(self, tmp_path, monkeypatch):
+        """Every directory skipped is not a successful run, whatever the reasons."""
+        _write_metadata(str(tmp_path))
+        os.makedirs(os.path.join(str(tmp_path), "TLR-000-empty"))
+        monkeypatch.setattr(sys, "argv", ["create_severity_summary.py", str(tmp_path)])
+
+        assert main() == 1
+
+    def test_missing_directory_still_exits_nonzero(self, monkeypatch):
+        monkeypatch.setattr(
+            sys, "argv", ["create_severity_summary.py", "/does/not/exist/at/all"]
+        )
+
+        assert main() == 1
+
+
+class TestRtfOutputUnchanged:
+    """The whole point of the ticket's 'no output change' constraint."""
+
+    def test_written_rtf_is_byte_identical_to_the_renderer_output(self, tmp_path):
+        _write_metadata(str(tmp_path))
+        tlr_dir = _usable_tlr_dir(str(tmp_path))
+
+        result = process_results_directory(str(tmp_path))
+
+        assessment = build_assessment(tlr_dir, _RUN_TIMESTAMP)
+        with open(result.written[0]) as fh:
+            assert fh.read() == render_rtf(assessment)

--- a/tidepool_data_science_simulator/projects/risk/gui_runner.py
+++ b/tidepool_data_science_simulator/projects/risk/gui_runner.py
@@ -58,14 +58,20 @@ from severity_model import (  # noqa: E402,F401
 # in that same non-packaged post_processing/ dir, so consumers reach it here
 # rather than replicating the sys.path insert. Used as-is; its RTF output is
 # untouched, so an exported summary is byte-identical to the CLI's.
-from create_severity_summary import process_results_directory  # noqa: E402,F401
+from create_severity_summary import (  # noqa: E402,F401
+    process_results_directory,
+    # The filename is defined by the module that READS it -- imported rather than
+    # re-declared here so the writer and reader cannot drift apart. Bound at
+    # module level so consumers keep importing it from this entry point.
+    METADATA_FILENAME,
+)
 
 
-# Written into save_dir at run time so a GUI run directory is a valid input to
-# create_severity_summary (which reads its run timestamp from this file, and
-# otherwise refuses the directory). Same filename and same {"timestamp": ...}
-# shape loop_risk_v2_0's __main__ writes, so the CLI path is unchanged.
-METADATA_FILENAME = "metadata.json"
+# metadata.json is written into save_dir at run time so a GUI run directory is a
+# valid input to create_severity_summary (which reads its run timestamp from that
+# file, and otherwise refuses the directory). Same filename and same
+# {"timestamp": ...} shape loop_risk_v2_0's __main__ writes, so the CLI path is
+# unchanged.
 
 
 @dataclass


### PR DESCRIPTION
[TRSET-27](https://tidepool.atlassian.net/browse/TRSET-27) — `create_severity_summary.process_results_directory` printed a diagnostic and returned `None` on every failure path, so no caller could tell a no-op run from a successful one. `main()` compounded it: `Done!` and exit `0` regardless, so a run that wrote nothing looked identical to one that wrote every summary — to a human reading the console *or* to CI reading the exit code.

## What changed

| Condition | Before | Now |
|---|---|---|
| `metadata.json` missing | print + return `None` | raises `SeveritySummaryError` |
| `metadata.json` unparseable | raw `JSONDecodeError` | raises `SeveritySummaryError` |
| no `timestamp` / `run_timestamp` key | summary dated `"Unknown"` | raises `SeveritySummaryError` |
| no `TLR-*` subdirectories | print + return `None` | raises `SeveritySummaryError` |
| one `TLR-*` dir yields no assessment | bare `continue` | reported in `result.skipped` |
| stray file named `TLR-*.txt` | passed to `build_assessment` | ignored (directories only) |
| processing order | `glob` order (varies by machine) | sorted |
| nothing written | `Done!`, exit `0` | error message, exit `1` |

- `process_results_directory` now returns `SummaryResult(written, skipped)` — the RTF paths it wrote, and `(tlr_dir, reason)` for each directory it didn't.
- A single `TLR-*` directory yielding no assessment stays a **partial outcome**, not an error: a real run can legitimately contain one, and the GUI already renders that state. It's reported, not raised.
- The `"Unknown"` timestamp fallback is gone. It rendered into the RTF's "Date and time of simulation run" field, i.e. a regulatory document dated with a placeholder.
- `gui_runner` imports `METADATA_FILENAME` from this module rather than re-declaring it, so the writer and reader of `metadata.json` can't drift apart. Still importable from `gui_runner`, so the GUI's import path is unchanged.

## Validation

**RTF bytes unchanged** — a test asserts the written file is byte-identical to `render_rtf`'s output, alongside the pre-existing 32-test renderer suite.

17 tests added (`test_create_severity_summary.py` had no coverage of this function at all): each raising condition, the `run_timestamp` fallback key still honored, per-directory skips, mixed runs, sorted order, the stray-`TLR-*`-file case, and all four CLI exit codes. That file is now **49/49**.

- Full simulator suite: **556 passed / 31 failed / 5 skipped** — the 31 are the documented pre-existing set, file-for-file (13 in `test_validate_configs_integration.py`, 18 in untracked local scratch).
- GUI suite **unaffected**: 138 passed / 7 skipped. Its export path pre-checks both fatal conditions itself and surfaces any exception in the UI, so no GUI change was needed.

## Migration

Behavior change, not a signature change: a caller relying on a quiet return must now catch `SeveritySummaryError`. Both in-repo callers are handled (CLI → exit `1`; GUI export → pre-checks + `st.error`). Ad-hoc scripts outside these repos may need a `try`/`except` — see `post_processing/README_create_severity_summary.md`.

Regression risk **Medium** (shared post-processing entry point used by both the CLI and the GUI export), contained by the byte-identical RTF output and the change touching only orchestration. `create_severity_summary_ORIGINAL.py` retains the old behavior and is deliberately untouched.

## Out of scope — filed for its own ticket

`severity_model.build_assessment` collapses distinct conditions into a single `None`, and its helpers degrade malformed data into "absent data" (a malformed CSV is reported in the RTF as "Data not available for outlier analysis"). This fix makes those returns *visible* at the boundary but doesn't change them. Details in the session note; will be addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TRSET-27]: https://tidepool.atlassian.net/browse/TRSET-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ