### PR TITLE
[bugfix] TRSET-28: report post-processing failures instead of misreporting them

### DIFF
--- a/post_processing/README_severity_model.md
+++ b/post_processing/README_severity_model.md
@@ -79,8 +79,15 @@ string above pinned verbatim. Clean-path byte-identity was additionally verified
 out-of-band by rendering the same fixture through the pre-change module and
 `diff`ing (1846 bytes, identical).
 
+A further 5 tests cover `gui_runner`'s migration (empty vs. malformed surfaced on
+`RiskDirRunResult`, and positional construction still working); its eight
+`build_assessment` monkeypatches now patch `build_assessment_result` and return a
+real `AssessmentOutcome`, so a fake of the wrong shape cannot pass. The unpatched
+path was additionally exercised out-of-band against real good/empty/malformed
+directories through `gui_runner`'s own import.
+
 Suites: `test_severity_model.py` + `test_create_severity_summary.py` +
-`tests/test_gui_runner.py` — 165 passed. Full suite: 644 passed / 8 failed / 5
+`tests/test_gui_runner.py` — 170 passed. Full suite: 649 passed / 8 failed / 5
 skipped, the 8 being pre-existing and unrelated (all in untracked local scratch
 files: `test_consensus_risk_list.py`, `test_jira_risk_probabilities.py`,
 `test_simulation_results_columns.py`) — verified identical on a stash of this change.
@@ -97,11 +104,19 @@ files: `test_consensus_risk_list.py`, `test_jira_risk_probabilities.py`,
   own mapping; unmapped, a malformed directory shows the GUI's fallback text rather
   than the `'no_data'` text it used to show.
 
-`build_assessment` is **unchanged** — still `Optional[SeverityAssessment]` — so
-`gui_runner.RiskDirRunResult` and the GUI repo that reads it need no change. That
-also means `gui_runner` still cannot tell empty from malformed; migrating it to
-`build_assessment_result` is a follow-up (it requires updating the eight
-`build_assessment` monkeypatches in `tests/test_gui_runner.py`).
+`build_assessment` is **unchanged** — still `Optional[SeverityAssessment]` — and
+stays importable from both `severity_model` and `gui_runner`, so a consumer that
+imports it keeps working.
+
+**`gui_runner` is migrated to `build_assessment_result`.** `RiskDirRunResult` gains
+two keyword-defaulted fields appended after the existing ones —
+`assessment_status` (`'ok'` | `'empty'` | `'malformed'`) and `assessment_detail` —
+so positional construction and existing field access are unaffected, and the GUI
+can now say *why* a directory produced no assessment instead of only "no data".
+`AssessmentOutcome` is re-exported from `gui_runner` for consumers that want to
+branch on the outcome directly. A GUI showing a single "no data" state for
+`assessment is None` still renders correctly; adopting `assessment_status` is
+opt-in.
 
 `SeverityAssessment.usable_profile_count` is additive and defaults to `None`
 ("not measured"), which renders as M == N — so an object built by an older

--- a/post_processing/README_severity_model.md
+++ b/post_processing/README_severity_model.md
@@ -1,0 +1,129 @@
+# Severity Model — failure reporting and profile counting
+
+## Description
+
+`severity_model.py` computes the structured `SeverityAssessment` that both the RTF
+renderer (`create_severity_summary.py`) and the GUI consume. **Bugfix (TRSET-28):**
+four silent or ambiguous failure behaviors in this layer are corrected —
+
+1. `build_assessment` returned a bare `None` for *both* an empty directory and
+   real-but-malformed data, so no caller could tell "nothing ran here" from "the
+   data is broken." There is now a typed `AssessmentOutcome` with
+   `status ∈ {'ok', 'empty', 'malformed'}`.
+2. Malformed profile data rendered to the reader as *absent* data: a corrupt CSV
+   produced a regulatory document asserting the data was unavailable. `detect_outliers`
+   now reports `'malformed_data'` separately from `'no_data'`, with its own text.
+3. The aggregated-profile count could **overstate** what contributed — `count_profiles`
+   counted files while `extract_metric_data` silently dropped malformed ones and
+   averaged the remainder. The assessment now carries both N (present) and M (usable).
+4. Five call sites used two different summary-CSV glob patterns, so a directory every
+   downstream helper could read was reported unusable. One pattern, defined once.
+
+Companion to [`README_create_severity_summary.md`](README_create_severity_summary.md)
+(TRSET-27, the `process_results_directory` failure contract this builds on).
+
+## Example usage
+
+```python
+from severity_model import build_assessment, build_assessment_result
+
+# Typed: tells an empty directory from malformed data.
+outcome = build_assessment_result(tlr_dir, timestamp)
+if outcome.status == 'empty':
+    ...                       # nothing ran here — a legitimate partial outcome
+elif outcome.status == 'malformed':
+    ...                       # data present and unusable — report outcome.detail
+else:
+    render(outcome.assessment)
+
+# Unchanged contract, for consumers typed on Optional[SeverityAssessment]:
+assessment = build_assessment(tlr_dir, timestamp)   # the assessment, or None
+```
+
+### What changed, per condition
+
+| Condition | Before | Now |
+|---|---|---|
+| directory with no summary CSVs | `None` | `AssessmentOutcome(status='empty')` |
+| CSVs present, none usable | **complete document, every metric `NA`/`0`** | `status='malformed'`, **no document** |
+| no filename yields a `TLR-` ID | `None` (from `summary_files[0]` only) | `status='malformed'`, after trying every filename |
+| CSVs match the loose pattern only | reported unusable | read, like every other helper |
+| one CSV of several malformed | counted as an aggregated profile | excluded from M, discrepancy rendered |
+| malformed CSV in outlier analysis | status `'no_data'` → "Data not available" | status `'malformed_data'` → its own text |
+| optional column (`lbgi`/`dka_index`) absent | printed "CSV file malformed" | printed as "will report NA" (it is a designed degrade) |
+
+### Rendered output
+
+RTF output is **byte-identical on the clean path** (M == N, well-formed data),
+verified against the pre-change module. Only degraded paths change text:
+
+| | Before | Now |
+|---|---|---|
+| M == N | `2 virtual patient profiles aggregated for this summary.` | *unchanged* |
+| 0 < M < N | `3 virtual patient profiles aggregated for this summary.` (named 3; 2 contributed) | `2 of 3 virtual patient profiles aggregated for this summary. 1 summary results file could not be read.` |
+| malformed outlier input | `Data not available for outlier analysis.` | `Outlier analysis not performed: profile data is present but could not be read. Check data configuration.` |
+| M == 0, N > 0 | a full document of `NA`/`0` | no document; reported as malformed |
+
+The malformed text deliberately does not name the offending file — the path stays in
+the console diagnostic and in `outcome.detail`; a regulatory document should not
+carry local filesystem paths.
+
+## Validation
+
+64 tests added (47 in `test_severity_model.py`, 17 in `test_create_severity_summary.py`):
+the empty/malformed split and its `to_dict` round-trip, the `build_assessment`
+wrapper contract, M vs. N including the every-required-column-is-load-bearing case,
+the usable/unusable split, `get_profile_metrics`/`detect_outliers` statuses, glob
+sharing plus a source-level DRY guard, simulation-ID fallback, and every rendered
+string above pinned verbatim. Clean-path byte-identity was additionally verified
+out-of-band by rendering the same fixture through the pre-change module and
+`diff`ing (1846 bytes, identical).
+
+Suites: `test_severity_model.py` + `test_create_severity_summary.py` +
+`tests/test_gui_runner.py` — 165 passed. Full suite: 644 passed / 8 failed / 5
+skipped, the 8 being pre-existing and unrelated (all in untracked local scratch
+files: `test_consensus_risk_list.py`, `test_jira_risk_probabilities.py`,
+`test_simulation_results_columns.py`) — verified identical on a stash of this change.
+
+## Cautions / limitations
+
+**Breaking changes — migration.** Two return contracts changed:
+
+- `get_profile_metrics` now returns `(profile_data, status)`, not a bare
+  `profile_data`/`None`. Callers must unpack.
+- `detect_outliers`' status set gains `'malformed_data'`. A consumer branching on
+  status must handle it, or it will fall through to whatever its `else` renders.
+  The GUI reads `SeverityAssessment.outlier_status` and needs the new value in its
+  own mapping; unmapped, a malformed directory shows the GUI's fallback text rather
+  than the `'no_data'` text it used to show.
+
+`build_assessment` is **unchanged** — still `Optional[SeverityAssessment]` — so
+`gui_runner.RiskDirRunResult` and the GUI repo that reads it need no change. That
+also means `gui_runner` still cannot tell empty from malformed; migrating it to
+`build_assessment_result` is a follow-up (it requires updating the eight
+`build_assessment` monkeypatches in `tests/test_gui_runner.py`).
+
+`SeverityAssessment.usable_profile_count` is additive and defaults to `None`
+("not measured"), which renders as M == N — so an object built by an older
+positional constructor is unaffected. `to_dict()` gains the key.
+
+**A directory that renders today can stop rendering:** M == 0 with N > 0 is now
+malformed rather than a document of `NA`/`0` values. This was approved deliberately
+(TRSET-28 Decision A) as the point of the ticket, but it is the one change that
+removes an output rather than correcting one.
+
+Regression risk **Medium** — a cross-module interface (`severity_model` → renderer →
+GUI) and rendered output — contained by clean-path byte-identity and by
+`build_assessment` keeping its signature. A revert is a single-commit revert.
+`create_severity_summary_ORIGINAL.py` retains the old behavior and is deliberately
+untouched (legacy reference copy).
+
+### Deliberately out of scope
+
+- The `detect_outliers` hyperglycemia deviation (`hyper_score = 1 if tar < 12.0 else 2`,
+  no zero case) — preserved exactly; a separate correctness decision.
+- Splitting the third condition still inside `'no_data'`: profiles that parse but
+  where none is complete across all three stages (TRSET-28 Decision B).
+- Analyzing the M usable profiles instead of abandoning outlier analysis on the
+  first malformed file — that changes which outliers are *found* (TRSET-28 Decision C).
+- `STAGE_PREFIXES` fragile prefix matching, noted in the module.

--- a/post_processing/README_severity_model.md
+++ b/post_processing/README_severity_model.md
@@ -133,10 +133,39 @@ GUI) and rendered output — contained by clean-path byte-identity and by
 `create_severity_summary_ORIGINAL.py` retains the old behavior and is deliberately
 untouched (legacy reference copy).
 
+## Hyperglycemia zero case (separate commit)
+
+`detect_outliers` computed its own TAR→score mapping, `hyper_score = 1 if tar < 12.0
+else 2`, with no zero case — contradicting SOP intent (a score of 0 should mean the
+index is truly 0) and disagreeing with `calculate_hyperglycemia_score`. It now calls
+that function, so the module has one such mapping.
+
+**The naive fix would have silently removed a detection.** With the corrected score,
+`determine_harm_and_severity(0, 0, 0)` is baseline, so a profile with TAR == 0 and no
+hypo/DKA risk leaves the `Hyperglycemia` harm group — and the zero-TAR outlier check
+keyed on that group. A profile with 0% time-above-range among all-high-TAR peers, the
+case most worth flagging, would have stopped being reported. Verified: 3 findings → 0.
+
+The check therefore spans the `Hyperglycemia` and baseline groups together. That union
+is provably the old `Hyperglycemia` group — baseline is exactly its `TAR == 0` subset
+of `lbgi <= 1 and dka == 0` — so the compared population is unchanged. It is evaluated
+at whichever of the two groups `harm_groups` reaches first, and built from
+`profile_harms` order, so findings keep their emitted order too.
+
+**Net effect: no rendered output changes.** The results table never used this mapping
+(`build_assessment` already used `calculate_hyperglycemia_score` on averaged TAR); the
+inline score fed only outlier grouping, and its `_severity` return was discarded.
+Equivalence was verified by an exhaustive sweep of `detect_outliers` across the fix —
+2, 3 and 4 profiles over a grid of TAR/LBGI/DKA values, comparing findings as ordered
+tuples: **133,632 cases, 0 differences**. The same sweep reports 1,044 differences for
+the naive fix, so it is not vacuous. 11 tests added, 3 of which fail against the naive
+fix.
+
+`BASELINE_HARM` names the baseline label, since `detect_outliers` now has to reason
+about that group and a typo would silently empty the union.
+
 ### Deliberately out of scope
 
-- The `detect_outliers` hyperglycemia deviation (`hyper_score = 1 if tar < 12.0 else 2`,
-  no zero case) — preserved exactly; a separate correctness decision.
 - Splitting the third condition still inside `'no_data'`: profiles that parse but
   where none is complete across all three stages (TRSET-28 Decision B).
 - Analyzing the M usable profiles instead of abandoning outlier analysis on the

--- a/post_processing/README_severity_model.md
+++ b/post_processing/README_severity_model.md
@@ -97,8 +97,10 @@ files: `test_consensus_risk_list.py`, `test_jira_risk_probabilities.py`,
 
 **Breaking changes — migration.** Two return contracts changed:
 
-- `get_profile_metrics` now returns `(profile_data, status)`, not a bare
-  `profile_data`/`None`. Callers must unpack.
+- `get_profile_metrics` now returns a `ProfileMetrics` object (`profiles`, `excluded`,
+  `files_present`), not a bare `profile_data`/`None`.
+- `render_outlier_results` takes two further optional arguments, `profile_count` and
+  `usable_profile_count`. Both default to `None`, so an existing call renders as before.
 - `detect_outliers`' status set gains `'malformed_data'` and `'incomplete_stages'`. A
   consumer branching on status must handle both, or they will fall through to whatever
   its `else` renders. The GUI reads `SeverityAssessment.outlier_status` and needs the
@@ -192,8 +194,49 @@ absent stages render `NA` as before.
 `render_outlier_results` falls through to the findings text for a status it does not
 recognize, so a future status cannot silently render a degraded sentence.
 
+## Excluding a bad profile instead of abandoning the analysis (separate commit)
+
+`get_profile_metrics` returned on the **first** unreadable file, so one bad profile
+cost the outlier analysis of every good one in the directory. This is the one change
+in TRSET-28 that alters which outliers are **found** (Decision C).
+
+An unreadable file is now excluded and named; the readable profiles are compared. A
+real example, three good profiles and one bad:
+
+| | Before | Now |
+|---|---|---|
+| Outlier Results | `Outlier analysis not performed: profile data is present but could not be read. Check data configuration.` | `Outlier profile exists. median has a Hypoglycemia score of 4 at Pre-mitigation, while other profiles have a Hypoglycemia score of 2. …` |
+
+A genuine severity-4 hypoglycemia outlier was being suppressed by an unrelated
+malformed file.
+
+Because the findings are scoped to what survived, the statuses that **assert**
+something about the profiles (`ok`, `single_profile`) carry a trailing sentence:
+*"This analysis covered 3 of 4 profiles; 1 could not be read."* The count line above
+already reports the drop, but the Outlier Results sentences are absolute claims read
+and quoted on their own. The three statuses that say the analysis did not happen are
+not scoped — that would only repeat the count line.
+
+`get_profile_metrics` now returns a `ProfileMetrics` (`profiles` / `excluded` /
+`files_present`) rather than a tuple; `files_present` is what distinguishes "nothing
+there" from "everything there was excluded", which an empty `profiles` cannot. A
+profile is published only once fully built, so a row-level failure part-way through
+can no longer leave a half-populated profile behind — it previously did not matter
+because any exception discarded the directory.
+
+**Two precedences moved, deliberately:**
+
+- `'malformed_data'` now means **every** per-profile file failed, not "at least one
+  did". Reaching it needs a usable non-profile file to keep M ≥ 1 (otherwise
+  `build_assessment_result` reports the directory malformed and writes no document).
+- `incomplete_stages` now **outranks** an excluded file, reversing the earlier
+  precedence. An unreadable file no longer poisons the directory, so what the reader
+  needs is the state of the data that remains: readable, but stage-thin.
+
+Equivalence on the clean path is unaffected: the `detect_outliers` sweep still
+reports 133,632 cases / 0 differences against the pre-TRSET-28 module, and RTF output
+is byte-identical when nothing is excluded.
+
 ### Deliberately out of scope
 
-- Analyzing the M usable profiles instead of abandoning outlier analysis on the
-  first malformed file — that changes which outliers are *found* (TRSET-28 Decision C).
 - `STAGE_PREFIXES` fragile prefix matching, noted in the module.

--- a/post_processing/README_severity_model.md
+++ b/post_processing/README_severity_model.md
@@ -62,6 +62,7 @@ verified against the pre-change module. Only degraded paths change text:
 | M == N | `2 virtual patient profiles aggregated for this summary.` | *unchanged* |
 | 0 < M < N | `3 virtual patient profiles aggregated for this summary.` (named 3; 2 contributed) | `2 of 3 virtual patient profiles aggregated for this summary. 1 summary results file could not be read.` |
 | malformed outlier input | `Data not available for outlier analysis.` | `Outlier analysis not performed: profile data is present but could not be read. Check data configuration.` |
+| no profile complete across all three stages | `Data not available for outlier analysis.` | `Outlier analysis not performed: no profile has results for all three evaluation stages.` |
 | M == 0, N > 0 | a full document of `NA`/`0` | no document; reported as malformed |
 
 The malformed text deliberately does not name the offending file — the path stays in
@@ -98,11 +99,11 @@ files: `test_consensus_risk_list.py`, `test_jira_risk_probabilities.py`,
 
 - `get_profile_metrics` now returns `(profile_data, status)`, not a bare
   `profile_data`/`None`. Callers must unpack.
-- `detect_outliers`' status set gains `'malformed_data'`. A consumer branching on
-  status must handle it, or it will fall through to whatever its `else` renders.
-  The GUI reads `SeverityAssessment.outlier_status` and needs the new value in its
-  own mapping; unmapped, a malformed directory shows the GUI's fallback text rather
-  than the `'no_data'` text it used to show.
+- `detect_outliers`' status set gains `'malformed_data'` and `'incomplete_stages'`. A
+  consumer branching on status must handle both, or they will fall through to whatever
+  its `else` renders. The GUI reads `SeverityAssessment.outlier_status` and needs the
+  new values in its own mapping; unmapped, those directories show the GUI's fallback
+  text rather than the `'no_data'` text they used to show.
 
 `build_assessment` is **unchanged** — still `Optional[SeverityAssessment]` — and
 stays importable from both `severity_model` and `gui_runner`, so a consumer that
@@ -164,10 +165,35 @@ fix.
 `BASELINE_HARM` names the baseline label, since `detect_outliers` now has to reason
 about that group and a typo would silently empty the union.
 
+## Incomplete stage coverage (separate commit)
+
+`detect_outliers` returned `'no_data'` from two places, and the second was not
+absence: profiles that parse fine but where **none carries results for all three
+stages**. That is a run which produced only some stages — a real, recoverable
+configuration problem — reported with the same sentence as a missing directory.
+
+It now reports `'incomplete_stages'`, rendering *"Outlier analysis not performed: no
+profile has results for all three evaluation stages."* The three degraded statuses are
+now three distinct sentences, and only genuine absence keeps the original text.
+
+Precedence, and why: `malformed_data` still outranks `incomplete_stages` — an
+unreadable file is the more actionable fault and makes the rest unknowable. A
+directory with *one* complete profile alongside incomplete ones is still
+`single_profile`, since the gate is "none complete", not "any incomplete".
+
+`'no_data'` now means exactly one thing: no per-profile results exist. That covers no
+summary files at all, and an aggregate-only directory whose filenames identify no
+profile (no `*_profile.csv`) — both genuine absence.
+
+**Thin data is not malformed data.** Such a directory still renders a document, and
+its files still count toward M, so finding 3's count line stays in its clean form and
+absent stages render `NA` as before.
+
+`render_outlier_results` falls through to the findings text for a status it does not
+recognize, so a future status cannot silently render a degraded sentence.
+
 ### Deliberately out of scope
 
-- Splitting the third condition still inside `'no_data'`: profiles that parse but
-  where none is complete across all three stages (TRSET-28 Decision B).
 - Analyzing the M usable profiles instead of abandoning outlier analysis on the
   first malformed file — that changes which outliers are *found* (TRSET-28 Decision C).
 - `STAGE_PREFIXES` fragile prefix matching, noted in the module.

--- a/post_processing/create_severity_summary.py
+++ b/post_processing/create_severity_summary.py
@@ -97,6 +97,12 @@ def render_outlier_results(outlier_findings, status):
         # diagnostic; a regulatory document should not carry local filesystem paths.
         return ("Outlier analysis not performed: profile data is present but could "
                 "not be read. Check data configuration.")
+    if status == 'incomplete_stages':
+        # Also NOT "Data not available": the data is present and readable, just too
+        # thin to compare across stages. Naming the cause is what lets a reader tell
+        # a partial run from a missing one.
+        return ("Outlier analysis not performed: no profile has results for all "
+                "three evaluation stages.")
     if status == 'no_data':
         return "Data not available for outlier analysis."
     if status == 'single_profile':

--- a/post_processing/create_severity_summary.py
+++ b/post_processing/create_severity_summary.py
@@ -28,9 +28,11 @@ import json
 from dataclasses import dataclass, field
 
 from severity_model import (
-    build_assessment,
+    build_assessment_result,
     STAGE_ORDER,
     STAGE_DISPLAY,
+    # re-exported for backwards-compat with existing tests:
+    build_assessment,                  # noqa: F401  (re-export)
     # re-exported for backwards-compat with existing tests:
     round_half_up,                     # noqa: F401  (re-export)
     calculate_integer_averages,        # noqa: F401  (re-export)
@@ -89,6 +91,12 @@ def render_outlier_results(outlier_findings, status):
     Reproduces the original generate_outlier_results_section() output exactly,
     driven by structured OutlierFinding objects + a status string.
     """
+    if status == 'malformed_data':
+        # NOT "Data not available": the data was there and could not be read.
+        # Deliberately does not name the file -- the path stays in the console
+        # diagnostic; a regulatory document should not carry local filesystem paths.
+        return ("Outlier analysis not performed: profile data is present but could "
+                "not be read. Check data configuration.")
     if status == 'no_data':
         return "Data not available for outlier analysis."
     if status == 'single_profile':
@@ -118,6 +126,29 @@ def render_outlier_results(outlier_findings, status):
     return " ".join(messages)
 
 
+def render_profile_count(profile_count, usable_profile_count=None):
+    """The 'N virtual patient profiles aggregated for this summary.' line.
+
+    profile_count is N (files present); usable_profile_count is M (files that could
+    contribute a value). M == N -- the normal clean-data case -- renders the
+    original sentence byte-for-byte. M < N surfaces the discrepancy, because
+    extract_metric_data drops a malformed file and averages the remainder, so the
+    unqualified count could name more profiles than contributed a single value.
+
+    usable_profile_count None means "not measured" and renders as M == N, so an
+    assessment built by an older positional constructor is unaffected.
+    """
+    if usable_profile_count is None or usable_profile_count >= profile_count:
+        return f"{profile_count} virtual patient profiles aggregated for this summary."
+    dropped = profile_count - usable_profile_count
+    noun = "file" if dropped == 1 else "files"
+    return (
+        f"{usable_profile_count} of {profile_count} virtual patient profiles "
+        f"aggregated for this summary. "
+        f"{dropped} summary results {noun} could not be read."
+    )
+
+
 def render_rtf(assessment):
     """Render a full RTF document string from a SeverityAssessment.
 
@@ -139,6 +170,9 @@ def render_rtf(assessment):
 
     catastrophic_content = render_catastrophic_identifier(assessment.catastrophic_findings)
     outlier_content = render_outlier_results(assessment.outlier_findings, assessment.outlier_status)
+    profile_count_content = render_profile_count(
+        assessment.profile_count, assessment.usable_profile_count
+    )
 
     rtf_content = r"""{\rtf1\ansi\deff0
 {\fonttbl{\f0 Arial;}}
@@ -207,7 +241,7 @@ Auto-generated output from Tidepool Risk Severity Evaluation Simulator Tool
 \pard
 \par\par
 
-""" + str(assessment.profile_count) + r""" virtual patient profiles aggregated for this summary.
+""" + profile_count_content + r"""
 \par\par
 
 {\b Critical/Catastrophic Identifier}
@@ -256,6 +290,12 @@ class SummaryResult:
     assessment. skipped: ``(tlr_dir, reason)`` for each directory that did not,
     so a caller can report them rather than silently shipping fewer summaries
     than there were directories.
+
+    The reason distinguishes an empty directory from malformed data (it used to be
+    one shared string for both). A caller that needs to BRANCH on which, rather
+    than report it, should call ``severity_model.build_assessment_result`` and read
+    its typed ``status``; the tuple shape is left alone so existing consumers of
+    ``skipped`` keep working.
     """
     written: list = field(default_factory=list)
     skipped: list = field(default_factory=list)
@@ -309,7 +349,8 @@ def process_results_directory(results_dir):
     Raises SeveritySummaryError if the directory cannot be summarized at all --
     unreadable/undated metadata.json, or no TLR-* subdirectory. A single TLR
     directory that yields no assessment is recorded in the result's ``skipped``
-    list instead, since a run legitimately can contain one.
+    list instead, since a run legitimately can contain one -- with a reason naming
+    whether it was empty or malformed.
     """
     timestamp = _read_run_timestamp(results_dir)
 
@@ -325,15 +366,19 @@ def process_results_directory(results_dir):
     for tlr_dir in tlr_dirs:
         print(f"\nProcessing: {tlr_dir}")
 
-        assessment = build_assessment(tlr_dir, timestamp)
+        outcome = build_assessment_result(tlr_dir, timestamp)
+        assessment = outcome.assessment
         if assessment is None:
-            reason = "no usable summary results data"
+            # 'empty' (nothing ran here) and 'malformed' (the data is broken) both
+            # used to report the same "no usable summary results data".
+            reason = f"{outcome.status}: {outcome.detail}"
             print(f"  Skipped: {reason}")
             result.skipped.append((tlr_dir, reason))
             continue
 
         print(f"  Simulation ID: {assessment.simulation_id}")
-        print(f"  Profile count: {assessment.profile_count}")
+        print(f"  Profile count: {assessment.usable_profile_count} usable of "
+              f"{assessment.profile_count} present")
 
         for stage, label in [('pre', 'Pre'), ('no_loop', 'No Loop'), ('post', 'Post')]:
             sr = assessment.stages[stage]

--- a/post_processing/create_severity_summary.py
+++ b/post_processing/create_severity_summary.py
@@ -85,11 +85,20 @@ def render_catastrophic_identifier(catastrophic_findings):
     return "\n".join(rtf_lines)
 
 
-def render_outlier_results(outlier_findings, status):
+def render_outlier_results(outlier_findings, status,
+                           profile_count=None, usable_profile_count=None):
     """Text for the Outlier Results section.
 
     Reproduces the original generate_outlier_results_section() output exactly,
     driven by structured OutlierFinding objects + a status string.
+
+    profile_count / usable_profile_count scope the claim. An unreadable profile is
+    now excluded from outlier analysis rather than abandoning it, so when fewer
+    profiles were analyzed than were present, the statuses that ASSERT something
+    about the profiles ('ok', 'single_profile') carry a sentence saying so. Without
+    it, "No outlier profiles exist. All results are within 1 severity level of one
+    another." reads as a claim over the whole run when it covered a subset. Both
+    default to None (unknown), which renders exactly as before.
     """
     if status == 'malformed_data':
         # NOT "Data not available": the data was there and could not be read.
@@ -105,11 +114,15 @@ def render_outlier_results(outlier_findings, status):
                 "three evaluation stages.")
     if status == 'no_data':
         return "Data not available for outlier analysis."
+
+    scope = _render_outlier_scope(profile_count, usable_profile_count)
+
     if status == 'single_profile':
-        return "Only one profile present, so outliers are not relevant."
+        return "Only one profile present, so outliers are not relevant." + scope
 
     if not outlier_findings:
-        return "No outlier profiles exist. All results are within 1 severity level of one another."
+        return ("No outlier profiles exist. All results are within 1 severity level "
+                "of one another.") + scope
 
     messages = []
     for f in outlier_findings:
@@ -129,7 +142,24 @@ def render_outlier_results(outlier_findings, status):
                 f"Outlier profile exists. {f.profile} has a Hyperglycemia percent_cgm_gt_180 of 0.0 at {stage_name}, "
                 f"while other profiles have a Hyperglycemia percent_cgm_gt_180 of {f.comparison_median:.1f}."
             )
-    return " ".join(messages)
+    return " ".join(messages) + scope
+
+
+def _render_outlier_scope(profile_count, usable_profile_count):
+    """A trailing sentence scoping an outlier claim to the profiles analyzed.
+
+    Empty -- so the section renders byte-for-byte as before -- unless profiles were
+    actually excluded. The count line above the section already reports the drop;
+    this repeats it inside the Outlier Results section because that section is read,
+    and quoted, on its own, and its sentences are absolute claims.
+    """
+    if profile_count is None or usable_profile_count is None:
+        return ""
+    if usable_profile_count >= profile_count:
+        return ""
+    excluded = profile_count - usable_profile_count
+    return (f" This analysis covered {usable_profile_count} of {profile_count} "
+            f"profiles; {excluded} could not be read.")
 
 
 def render_profile_count(profile_count, usable_profile_count=None):
@@ -175,7 +205,10 @@ def render_rtf(assessment):
     dkai = {stage: stages[stage].dka_index_value_avg for stage in STAGE_ORDER}
 
     catastrophic_content = render_catastrophic_identifier(assessment.catastrophic_findings)
-    outlier_content = render_outlier_results(assessment.outlier_findings, assessment.outlier_status)
+    outlier_content = render_outlier_results(
+        assessment.outlier_findings, assessment.outlier_status,
+        assessment.profile_count, assessment.usable_profile_count,
+    )
     profile_count_content = render_profile_count(
         assessment.profile_count, assessment.usable_profile_count
     )

--- a/post_processing/severity_model.py
+++ b/post_processing/severity_model.py
@@ -28,9 +28,9 @@ status and SeverityAssessment.usable_profile_count. See README_severity_model.md
 Provenance flags on scores:
   - round-half-up on averaged scores: script convention (conservative), NOT SOP-mandated.
   - hyperglycemia TAR->score mapping: script convention; DOC-0015 treats hyperglycemia as
-    secondary and defines no TAR->severity map. The main-path mapping
-    (calculate_hyperglycemia_score) honors SOP intent that a score of 0 means the index
-    is truly 0. See KNOWN INCONSISTENCY note in detect_outliers().
+    secondary and defines no TAR->severity map. calculate_hyperglycemia_score honors SOP
+    intent that a score of 0 means the index is truly 0, and is now the ONLY mapping in
+    the module -- detect_outliers used to compute its own without a zero case.
 """
 
 import math
@@ -75,6 +75,12 @@ STAGE_PREFIXES = {
 
 STAGE_ORDER = ['pre', 'no_loop', 'post']
 STAGE_DISPLAY = {'pre': 'Pre-mitigation', 'no_loop': 'No Loop', 'post': 'Post-mitigation'}
+
+# The harm label for "no harm indicated" (all three component scores zero). Named
+# because detect_outliers has to reason about this group as well as 'Hyperglycemia'
+# -- see the hyperglycemia-axis comment there. The string is the RTF cell text, so
+# it is exactly what determine_harm_and_severity returned before it was named.
+BASELINE_HARM = 'Severity = baseline'
 
 
 # =============================================================================
@@ -451,7 +457,7 @@ def determine_harm_and_severity(lbgi_score, dka_score, hyperglycemia_score):
       - else -> DKA (score = dka)
     """
     if lbgi_score == 0 and dka_score == 0 and hyperglycemia_score == 0:
-        return ("Severity = baseline", "0")
+        return (BASELINE_HARM, "0")
     if lbgi_score <= 1 and dka_score == 0:
         return ("Hyperglycemia", str(hyperglycemia_score))
     if lbgi_score >= dka_score:
@@ -625,17 +631,20 @@ def detect_outliers(tlr_dir, severity_updates=None):
     findings lives in the consumer (create_severity_summary.render_*).
 
     ---------------------------------------------------------------------------
-    KNOWN INCONSISTENCY (preserved deliberately; flagged for adjudication):
-    This function computes each profile's per-stage hyperglycemia score inline as
+    RESOLVED (was: KNOWN INCONSISTENCY). This function used to compute each
+    profile's per-stage hyperglycemia score inline as
         hyper_score = 1 if tar < 12.0 else 2
-    which has NO zero case. This CONTRADICTS SOP intent (a score of 0 should mean
-    the index — TAR% — is truly 0), and it differs from the main path's
-    calculate_hyperglycemia_score(), which correctly returns 0 for TAR==0.0.
+    which has NO zero case, contradicting SOP intent (a score of 0 should mean the
+    index -- TAR% -- is truly 0) and disagreeing with calculate_hyperglycemia_score.
+    It now calls that function, so the module has ONE such mapping.
 
-    The main path is the SOP-correct one; the outlier path is the deviant one.
-    It is preserved here EXACTLY so the refactor produces byte-identical output.
-    Do NOT "fix" it as part of the refactor — changing it alters results and is a
-    separate, deliberate correctness decision for Shawn to make.
+    Correcting the score reclassifies a profile with TAR == 0 and no hypo/DKA risk:
+    determine_harm_and_severity(0, 0, 0) is baseline, where the old score of 1 made
+    it 'Hyperglycemia'. Since the zero-TAR outlier check keyed on that group, the
+    naive fix would have silently STOPPED FLAGGING the cleanest profiles. The check
+    now spans the Hyperglycemia and baseline groups together -- provably the same
+    population as the old Hyperglycemia group -- so no finding is gained or lost.
+    See the hyperglycemia-axis block below.
     ---------------------------------------------------------------------------
     """
     profile_data, metrics_status = get_profile_metrics(tlr_dir, severity_updates)
@@ -670,8 +679,8 @@ def detect_outliers(tlr_dir, severity_updates=None):
             lbgi = stages[stage]['lbgi']
             dka = stages[stage]['dka']
             tar = stages[stage]['tar']
-            # PRESERVED inconsistency (see docstring): no zero case here.
-            hyper_score = 1 if tar < 12.0 else 2
+            # The module's single TAR->score mapping (see the RESOLVED note above).
+            hyper_score = calculate_hyperglycemia_score(tar)
             harm, _severity = determine_harm_and_severity(lbgi, dka, hyper_score)
             profile_harms[profile] = {'harm': harm, 'lbgi': lbgi, 'dka': dka, 'tar': tar}
 
@@ -680,7 +689,42 @@ def detect_outliers(tlr_dir, severity_updates=None):
         for profile, data in profile_harms.items():
             harm_groups.setdefault(data['harm'], []).append(profile)
 
+        # The hyperglycemia-AXIS population: profiles compared on TAR% rather than
+        # on a risk score. It spans two harm groups, because a profile with TAR == 0
+        # and no hypo/DKA risk is now correctly 'Severity = baseline' rather than
+        # 'Hyperglycemia'. Their union is exactly the old Hyperglycemia group
+        # ('lbgi <= 1 and dka == 0' -- baseline is the subset of that with TAR == 0),
+        # so the compared population is unchanged by the score fix.
+        #
+        # Built from profile_harms, so profile order matches complete_profiles order
+        # as the per-group lists did; and evaluated at whichever of the two groups
+        # harm_groups reaches first, which is where the undivided Hyperglycemia group
+        # sat. Findings therefore keep both their identity and their emitted order.
+        hyper_axis_harms = ('Hyperglycemia', BASELINE_HARM)
+        hyper_axis_profiles = [
+            profile for profile, data in profile_harms.items()
+            if data['harm'] in hyper_axis_harms
+        ]
+        hyper_axis_at = next(
+            (harm_type for harm_type in harm_groups if harm_type in hyper_axis_harms),
+            None,
+        )
+
         for harm_type, profiles in harm_groups.items():
+            if harm_type == hyper_axis_at and len(hyper_axis_profiles) >= 2:
+                zero_profiles = [p for p in hyper_axis_profiles if profile_harms[p]['tar'] == 0.0]
+                non_zero_profiles = [p for p in hyper_axis_profiles if profile_harms[p]['tar'] != 0.0]
+                if len(zero_profiles) > 0 and len(non_zero_profiles) > 0:
+                    all_others_high = all(profile_harms[p]['tar'] >= 12.0 for p in non_zero_profiles)
+                    if all_others_high:
+                        non_zero_tars = [profile_harms[p]['tar'] for p in non_zero_profiles]
+                        median_tar = sorted(non_zero_tars)[len(non_zero_tars) // 2]
+                        for zero_profile in zero_profiles:
+                            findings.append(OutlierFinding(
+                                stage=stage, profile=zero_profile, harm_type='Hyperglycemia',
+                                value=0.0, comparison_median=float(median_tar),
+                            ))
+
             if len(profiles) < 2:
                 continue
 
@@ -705,20 +749,6 @@ def detect_outliers(tlr_dir, severity_updates=None):
                             stage=stage, profile=profile, harm_type='DKA',
                             value=float(dka), comparison_median=float(median_dka),
                         ))
-
-            if harm_type == 'Hyperglycemia':
-                zero_profiles = [p for p in profiles if profile_harms[p]['tar'] == 0.0]
-                non_zero_profiles = [p for p in profiles if profile_harms[p]['tar'] != 0.0]
-                if len(zero_profiles) > 0 and len(non_zero_profiles) > 0:
-                    all_others_high = all(profile_harms[p]['tar'] >= 12.0 for p in non_zero_profiles)
-                    if all_others_high:
-                        non_zero_tars = [profile_harms[p]['tar'] for p in non_zero_profiles]
-                        median_tar = sorted(non_zero_tars)[len(non_zero_tars) // 2]
-                        for zero_profile in zero_profiles:
-                            findings.append(OutlierFinding(
-                                stage=stage, profile=zero_profile, harm_type='Hyperglycemia',
-                                value=0.0, comparison_median=float(median_tar),
-                            ))
 
     return (findings, 'ok')
 

--- a/post_processing/severity_model.py
+++ b/post_processing/severity_model.py
@@ -521,28 +521,48 @@ def extract_profile_from_filename(csv_path):
     return None
 
 
+@dataclass
+class ProfileMetrics:
+    """Outlier-detection inputs for one TLR directory, and what was left out.
+
+    profiles:      profile name -> stage -> {'lbgi', 'dka', 'tar'}
+    excluded:      paths of per-profile summary files that could not contribute
+    files_present: whether the directory held any summary results files at all.
+                   Distinguishes "nothing there" from "everything there was excluded",
+                   which an empty ``profiles`` dict alone cannot.
+    """
+    profiles: dict = field(default_factory=dict)
+    excluded: list = field(default_factory=list)
+    files_present: bool = True
+
+    def to_dict(self):
+        return {
+            'profiles': self.profiles,
+            'excluded': list(self.excluded),
+            'files_present': self.files_present,
+        }
+
+
 def get_profile_metrics(tlr_dir, severity_updates=None):
     """Per-profile, per-stage {lbgi, dka, tar} for outlier detection.
 
-    Returns ``(profile_data, status)``:
-      'ok'              -> profile_data is a dict (possibly empty, if no filename
-                           yielded a profile name)
-      'no_data'         -> no summary results files at all; profile_data is None
-      'malformed_data'  -> files present but unreadable or missing a required
-                           column; profile_data is None
+    Returns a ProfileMetrics. An unreadable file is EXCLUDED and named, rather than
+    abandoning the directory: one bad profile used to cost the outlier analysis of
+    every good one, which is a strictly worse regulatory outcome than analyzing the
+    readable profiles and disclosing the scope. The exclusions travel with the data
+    so the caller can do that disclosing -- see detect_outliers and
+    create_severity_summary.render_outlier_results.
 
-    CONTRACT CHANGE: this used to return a bare ``None`` for both the absent and
-    the malformed case, collapsing them into detect_outliers' 'no_data' and thence
-    into an RTF line asserting the data was *unavailable* rather than *unusable*.
-    A malformed file still abandons the whole analysis (unchanged -- partially
-    analyzing would change which outliers are FOUND, a results change out of scope
-    here); it is only the REPORTING of that refusal that is now accurate.
+    CONTRACT CHANGE (twice over on this branch): this returned a bare
+    ``profile_data``/``None``, then ``(profile_data, status)``. Callers now read
+    ``.profiles`` / ``.excluded`` / ``.files_present``.
     """
     import pandas as pd
-    profile_data = {}
     csv_files = find_summary_files(tlr_dir)
     if not csv_files:
-        return (None, 'no_data')
+        return ProfileMetrics(files_present=False)
+
+    metrics = ProfileMetrics()
     for csv_file in csv_files:
         profile_name = extract_profile_from_filename(csv_file)
         if not profile_name:
@@ -550,9 +570,15 @@ def get_profile_metrics(tlr_dir, severity_updates=None):
         try:
             df = pd.read_csv(csv_file)
             if not all(col in df.columns for col in REQUIRED_SUMMARY_COLUMNS):
-                print(f"  Summary results file missing required columns: {csv_file}")
-                return (None, 'malformed_data')
-            profile_data[profile_name] = {'pre': {}, 'no_loop': {}, 'post': {}}
+                print(f"  Summary results file missing required columns, excluded "
+                      f"from outlier analysis: {csv_file}")
+                metrics.excluded.append(csv_file)
+                continue
+            # Built into a local dict and only then published, so a row-level
+            # failure part-way through cannot leave a half-populated profile in
+            # `profiles` -- it used to not matter, because any exception discarded
+            # the whole directory.
+            stages = {'pre': {}, 'no_loop': {}, 'post': {}}
             for _, row in df.iterrows():
                 sim_id = row['sim_id']
                 lbgi_score = row['lbgi_risk_score']
@@ -564,16 +590,18 @@ def get_profile_metrics(tlr_dir, severity_updates=None):
                     continue
                 stage = classify_sim_id(sim_id)
                 if stage is not None:
-                    profile_data[profile_name][stage] = {
+                    stages[stage] = {
                         'lbgi': int(lbgi_score),
                         'dka': int(dka_score),
                         'tar': float(tar_value),
                     }
+            metrics.profiles[profile_name] = stages
         except Exception as e:
-            print(f"  Error processing CSV for outlier detection: {csv_file}")
+            print(f"  Error processing CSV for outlier detection, excluded: {csv_file}")
             print(f"  Error details: {e}")
-            return (None, 'malformed_data')
-    return (profile_data, 'ok')
+            metrics.excluded.append(csv_file)
+            continue
+    return metrics
 
 
 def extract_simulation_id(summary_file_path):
@@ -614,17 +642,22 @@ def detect_outliers(tlr_dir, severity_updates=None):
         status_str is one of:
           'ok'                -> findings list is authoritative (may be empty)
           'no_data'           -> no per-profile results exist to compare
-          'malformed_data'    -> data IS present but unreadable/missing a required
-                                 column, so the analysis was not performed
+          'malformed_data'    -> every per-profile file was unreadable/missing a
+                                 required column, so nothing survived to analyze
           'incomplete_stages' -> profiles exist and parse, but none carries results
                                  for all three stages, so there is nothing to
                                  compare like-for-like
-          'single_profile'    -> only one profile, outliers not meaningful
+          'single_profile'    -> only one analyzable profile, outliers not meaningful
 
     'no_data' used to cover all three of absent, malformed and incomplete input,
     which the renderer then reported as "Data not available" -- a regulatory
     document asserting the data was missing when it was in fact corrupt, or real but
     thin. All three are now separate, and only genuine absence keeps that sentence.
+
+    A single unreadable file no longer costs the analysis of every readable profile:
+    it is excluded and the rest are compared. The findings are therefore scoped to
+    the profiles that survived, which the renderer discloses from the assessment's
+    usable-vs-total counts. 'malformed_data' now means every one of them failed.
 
     This is the detection half only. Rendering the RTF/GUI text from these
     findings lives in the consumer (create_severity_summary.render_*).
@@ -646,17 +679,19 @@ def detect_outliers(tlr_dir, severity_updates=None):
     See the hyperglycemia-axis block below.
     ---------------------------------------------------------------------------
     """
-    profile_data, metrics_status = get_profile_metrics(tlr_dir, severity_updates)
-
-    if metrics_status == 'malformed_data':
-        print("  Summary results data present but unusable; check data configuration.")
-        return ([], 'malformed_data')
+    metrics = get_profile_metrics(tlr_dir, severity_updates)
+    profile_data = metrics.profiles
 
     if not profile_data:
-        # Either no summary files at all (get_profile_metrics said 'no_data', and
-        # profile_data is None), or files whose names identify no profile -- an
-        # aggregate-only directory with no '*_profile.csv'. Either way there are no
-        # per-profile results in existence to compare, which is what 'no_data' means.
+        if metrics.excluded:
+            # Every per-profile file there was got excluded, so nothing survives to
+            # analyze. This is the only path left to 'malformed_data': a single bad
+            # file among good ones is now excluded and the rest analyzed.
+            print("  Summary results data present but unusable; check data configuration.")
+            return ([], 'malformed_data')
+        # No summary files at all, or files whose names identify no profile -- an
+        # aggregate-only directory with no '*_profile.csv'. Either way no per-profile
+        # results exist to compare, which is what 'no_data' means.
         print("  Necessary data not present; check configurations.")
         return ([], 'no_data')
 

--- a/post_processing/severity_model.py
+++ b/post_processing/severity_model.py
@@ -18,6 +18,13 @@ SOP grounding (see 'Using the Tidepool Risk Severity Evaluation Tool' docs):
   - Averaging across profiles per stage (TWI-0006 2.g).
   - Catastrophic 4->5 escalation read from the TSV (DOC-0015 Table 1 / TWI-0006 2.f).
 
+Failure reporting (TRSET-28): a directory that cannot be assessed reports WHY.
+build_assessment_result returns an AssessmentOutcome whose status separates a
+genuinely empty directory from real-but-malformed data; build_assessment remains a
+wrapper returning Optional[SeverityAssessment] for consumers typed on it. Malformed
+input is never reported as absent input -- see detect_outliers' 'malformed_data'
+status and SeverityAssessment.usable_profile_count. See README_severity_model.md.
+
 Provenance flags on scores:
   - round-half-up on averaged scores: script convention (conservative), NOT SOP-mandated.
   - hyperglycemia TAR->score mapping: script convention; DOC-0015 treats hyperglycemia as
@@ -68,6 +75,46 @@ STAGE_PREFIXES = {
 
 STAGE_ORDER = ['pre', 'no_loop', 'post']
 STAGE_DISPLAY = {'pre': 'Pre-mitigation', 'no_loop': 'No Loop', 'post': 'Post-mitigation'}
+
+
+# =============================================================================
+# Summary results discovery (single source of truth)
+# -----------------------------------------------------------------------------
+# The module previously matched summary CSVs with two different patterns:
+# build_assessment required 'summary_results_Simulation-Configuration-TLR*.csv'
+# while count_profiles, extract_metric_data, get_profile_metrics and
+# identify_severity_4_hypoglycemia all used the looser 'summary_results_*.csv'. A
+# directory matching only the loose pattern was therefore reported unusable even
+# though every downstream helper would have read it. All five now go through
+# find_summary_files().
+#
+# REQUIRED_SUMMARY_COLUMNS is the set a summary CSV must carry to contribute to
+# the severity VERDICT: the sim identity plus the three columns that feed
+# determine_harm_and_severity. TIR/TBR ('percent_values_ge_70_le_180',
+# 'percent_cgm_lt_54') and the raw values ('lbgi', 'dka_index') are *reported*
+# metrics, not verdict inputs -- they degrade to 'NA' by design, so their absence
+# must not mark a file malformed.
+# =============================================================================
+
+SUMMARY_RESULTS_GLOB = 'summary_results_*.csv'
+
+REQUIRED_SUMMARY_COLUMNS = (
+    'sim_id',
+    'lbgi_risk_score',
+    'dka_risk_score',
+    'percent_cgm_gt_180',
+)
+
+
+def find_summary_files(tlr_dir):
+    """Every summary results CSV in tlr_dir, sorted.
+
+    Sorted, not raw glob order: simulation-ID resolution reads the filenames in
+    order, and glob returns whatever the filesystem hands back. Under the old
+    narrow pattern every match carried the same 'Simulation-Configuration-TLR'
+    stem so arbitrary order was harmless; under the loose pattern it is not.
+    """
+    return sorted(glob.glob(os.path.join(tlr_dir, SUMMARY_RESULTS_GLOB)))
 
 
 def classify_sim_id(sim_id):
@@ -154,11 +201,17 @@ class SeverityAssessment:
     simulation_id: str
     subdirectory_name: str
     timestamp: str
-    profile_count: int
+    profile_count: int              # N: total summary results files present
     stages: dict                    # stage -> StageResult
     catastrophic_findings: list = field(default_factory=list)   # list[CatastrophicFinding]
     outlier_findings: list = field(default_factory=list)        # list[OutlierFinding]
-    outlier_status: str = 'ok'      # 'ok' | 'no_data' | 'single_profile'
+    # 'ok' | 'no_data' | 'malformed_data' | 'single_profile'
+    outlier_status: str = 'ok'
+    # M: how many of the N files could actually contribute a value. None means
+    # "not measured" and is treated as M == N by consumers, so an object built by
+    # an older positional constructor renders exactly as it used to.
+    # build_assessment always populates it.
+    usable_profile_count: Optional[int] = None
 
     def to_dict(self):
         return {
@@ -166,6 +219,7 @@ class SeverityAssessment:
             'subdirectory_name': self.subdirectory_name,
             'timestamp': self.timestamp,
             'profile_count': self.profile_count,
+            'usable_profile_count': self.usable_profile_count,
             'stages': {stage: sr.to_dict() for stage, sr in self.stages.items()},
             'catastrophic_findings': [c.to_dict() for c in self.catastrophic_findings],
             'outlier_findings': [o.to_dict() for o in self.outlier_findings],
@@ -233,7 +287,7 @@ def identify_severity_4_hypoglycemia(tlr_dir):
     """Find all sim_ids with lbgi_risk_score == 4, mapped to their stage."""
     import pandas as pd
     severity_4_sim_ids = {}
-    csv_files = glob.glob(os.path.join(tlr_dir, 'summary_results_*.csv'))
+    csv_files = find_summary_files(tlr_dir)
     for csv_file in csv_files:
         try:
             df = pd.read_csv(csv_file)
@@ -285,7 +339,7 @@ def extract_metric_data(tlr_dir, column_name, severity_updates=None):
     """
     import pandas as pd
     metric_data = {'pre': [], 'no_loop': [], 'post': []}
-    csv_files = glob.glob(os.path.join(tlr_dir, 'summary_results_*.csv'))
+    csv_files = find_summary_files(tlr_dir)
     if not csv_files:
         print(f"  Warning: No CSV files found in {tlr_dir}")
         return metric_data
@@ -293,7 +347,16 @@ def extract_metric_data(tlr_dir, column_name, severity_updates=None):
         try:
             df = pd.read_csv(csv_file)
             if 'sim_id' not in df.columns or column_name not in df.columns:
-                print(f"  CSV file malformed; check data configuration: {csv_file}")
+                # A REQUIRED column absent means the file is malformed. An
+                # optional/reported column absent is the designed 'NA' degrade
+                # (older CSVs predate 'lbgi'/'dka_index'), so calling it
+                # malformed cried wolf on valid data -- but it is still not
+                # silent: say which metric will report NA.
+                if 'sim_id' not in df.columns or column_name in REQUIRED_SUMMARY_COLUMNS:
+                    print(f"  CSV file malformed; check data configuration: {csv_file}")
+                else:
+                    print(f"  Column '{column_name}' not present in {csv_file}; "
+                          f"this metric will report NA.")
                 continue
             for _, row in df.iterrows():
                 sim_id = row['sim_id']
@@ -397,8 +460,45 @@ def determine_harm_and_severity(lbgi_score, dka_score, hyperglycemia_score):
 
 
 def count_profiles(tlr_dir):
-    """Number of summary_results_*.csv files (== profile count)."""
-    return len(glob.glob(os.path.join(tlr_dir, 'summary_results_*.csv')))
+    """Number of summary results files (== total profile count, N).
+
+    This is the TOTAL, which is not the same as the number that CONTRIBUTED a
+    value -- see count_usable_profiles for M.
+    """
+    return len(find_summary_files(tlr_dir))
+
+
+def classify_summary_files(tlr_dir):
+    """Split the directory's summary CSVs into (usable, unusable) path lists.
+
+    Usable means: parses as CSV and carries every REQUIRED_SUMMARY_COLUMNS entry,
+    i.e. it can contribute to the severity verdict. This is what separates
+    "N profiles were aggregated" from "N files were present": extract_metric_data
+    skips a malformed file and averages the remainder, so the file count alone
+    could name more profiles than contributed a single value.
+    """
+    import pandas as pd
+    usable, unusable = [], []
+    for csv_file in find_summary_files(tlr_dir):
+        try:
+            df = pd.read_csv(csv_file)
+        except Exception as e:
+            print(f"  Summary results file unreadable: {csv_file}")
+            print(f"  Error details: {e}")
+            unusable.append(csv_file)
+            continue
+        missing = [col for col in REQUIRED_SUMMARY_COLUMNS if col not in df.columns]
+        if missing:
+            print(f"  Summary results file missing required column(s) {missing}: {csv_file}")
+            unusable.append(csv_file)
+            continue
+        usable.append(csv_file)
+    return usable, unusable
+
+
+def count_usable_profiles(tlr_dir):
+    """Number of summary results files that can contribute a value (M)."""
+    return len(classify_summary_files(tlr_dir)[0])
 
 
 def extract_profile_from_filename(csv_path):
@@ -418,22 +518,34 @@ def extract_profile_from_filename(csv_path):
 def get_profile_metrics(tlr_dir, severity_updates=None):
     """Per-profile, per-stage {lbgi, dka, tar} for outlier detection.
 
-    Returns None if any CSV is malformed/missing required columns (preserves original).
+    Returns ``(profile_data, status)``:
+      'ok'              -> profile_data is a dict (possibly empty, if no filename
+                           yielded a profile name)
+      'no_data'         -> no summary results files at all; profile_data is None
+      'malformed_data'  -> files present but unreadable or missing a required
+                           column; profile_data is None
+
+    CONTRACT CHANGE: this used to return a bare ``None`` for both the absent and
+    the malformed case, collapsing them into detect_outliers' 'no_data' and thence
+    into an RTF line asserting the data was *unavailable* rather than *unusable*.
+    A malformed file still abandons the whole analysis (unchanged -- partially
+    analyzing would change which outliers are FOUND, a results change out of scope
+    here); it is only the REPORTING of that refusal that is now accurate.
     """
     import pandas as pd
     profile_data = {}
-    csv_files = glob.glob(os.path.join(tlr_dir, 'summary_results_*.csv'))
+    csv_files = find_summary_files(tlr_dir)
     if not csv_files:
-        return None
+        return (None, 'no_data')
     for csv_file in csv_files:
         profile_name = extract_profile_from_filename(csv_file)
         if not profile_name:
             continue
         try:
             df = pd.read_csv(csv_file)
-            required_cols = ['sim_id', 'lbgi_risk_score', 'dka_risk_score', 'percent_cgm_gt_180']
-            if not all(col in df.columns for col in required_cols):
-                return None
+            if not all(col in df.columns for col in REQUIRED_SUMMARY_COLUMNS):
+                print(f"  Summary results file missing required columns: {csv_file}")
+                return (None, 'malformed_data')
             profile_data[profile_name] = {'pre': {}, 'no_loop': {}, 'post': {}}
             for _, row in df.iterrows():
                 sim_id = row['sim_id']
@@ -454,8 +566,8 @@ def get_profile_metrics(tlr_dir, severity_updates=None):
         except Exception as e:
             print(f"  Error processing CSV for outlier detection: {csv_file}")
             print(f"  Error details: {e}")
-            return None
-    return profile_data
+            return (None, 'malformed_data')
+    return (profile_data, 'ok')
 
 
 def extract_simulation_id(summary_file_path):
@@ -465,6 +577,22 @@ def extract_simulation_id(summary_file_path):
     for i, part in enumerate(parts):
         if part == 'TLR':
             return f"TLR-{parts[i + 1].split('.')[0].split('_')[0]}"
+    return None
+
+
+def resolve_simulation_id(summary_files):
+    """The first TLR ID any of these filenames yields, or None if none does.
+
+    build_assessment used to read summary_files[0] alone. Under the old narrow
+    glob every candidate carried the 'Simulation-Configuration-TLR' stem, so
+    whichever one glob returned first gave the same answer. The loose glob admits
+    filenames with no TLR part, so taking [0] blindly would skip a directory that
+    renders today purely on filesystem ordering.
+    """
+    for summary_file in summary_files:
+        simulation_id = extract_simulation_id(summary_file)
+        if simulation_id:
+            return simulation_id
     return None
 
 
@@ -479,8 +607,19 @@ def detect_outliers(tlr_dir, severity_updates=None):
         (list[OutlierFinding], status_str)
         status_str is one of:
           'ok'                -> findings list is authoritative (may be empty)
-          'no_data'           -> data missing/malformed
+          'no_data'           -> the data needed for the comparison is not present
+          'malformed_data'    -> data IS present but unreadable/missing a required
+                                 column, so the analysis was not performed
           'single_profile'    -> only one profile, outliers not meaningful
+
+    'no_data' used to cover both absent and malformed input, which the renderer
+    then reported as "Data not available" -- a regulatory document asserting the
+    data was missing when in fact it was corrupt. The two are now separate.
+
+    Note: a directory whose profiles parse but where no profile is complete across
+    all three stages still reports 'no_data' -- the data needed for the comparison
+    genuinely is not available. That third condition is deliberately not split out
+    here (TRSET-28 Decision B).
 
     This is the detection half only. Rendering the RTF/GUI text from these
     findings lives in the consumer (create_severity_summary.render_*).
@@ -499,7 +638,11 @@ def detect_outliers(tlr_dir, severity_updates=None):
     separate, deliberate correctness decision for Shawn to make.
     ---------------------------------------------------------------------------
     """
-    profile_data = get_profile_metrics(tlr_dir, severity_updates)
+    profile_data, metrics_status = get_profile_metrics(tlr_dir, severity_updates)
+
+    if metrics_status == 'malformed_data':
+        print("  Summary results data present but unusable; check data configuration.")
+        return ([], 'malformed_data')
 
     if profile_data is None:
         print("  Necessary data not present; check configurations.")
@@ -584,26 +727,88 @@ def detect_outliers(tlr_dir, severity_updates=None):
 # Orchestrator — build the structured assessment (no I/O side effects beyond reads)
 # =============================================================================
 
+@dataclass
+class AssessmentOutcome:
+    """What build_assessment_result found in one TLR directory.
+
+    status:
+      'ok'        -> assessment is a SeverityAssessment
+      'empty'     -> no summary results files at all (nothing ran here);
+                     assessment is None
+      'malformed' -> summary files ARE present but none is usable, or none names a
+                     TLR simulation; assessment is None
+
+    'empty' and 'malformed' both used to be a bare None, so a caller could not tell
+    "nothing ran here" from "the data is broken." Both remain PARTIAL outcomes for
+    one directory -- neither is raised, so a run containing one still summarizes
+    every other directory (TRSET-27's fatal-vs-partial split).
+
+    detail is a human-readable reason a caller can report verbatim.
+    """
+    assessment: Optional[SeverityAssessment]
+    status: str
+    detail: str = ''
+
+    def to_dict(self):
+        return {
+            'assessment': self.assessment.to_dict() if self.assessment else None,
+            'status': self.status,
+            'detail': self.detail,
+        }
+
+
 def build_assessment(tlr_dir, timestamp):
-    """Build a SeverityAssessment for one TLR directory.
+    """The SeverityAssessment for one TLR directory, or None if unusable.
+
+    Backwards-compatible wrapper over build_assessment_result(), kept so consumers
+    typed on Optional[SeverityAssessment] -- the GUI runner's RiskDirRunResult, and
+    the GUI repo that reads it -- keep working unchanged. A caller that needs to
+    tell an empty directory from malformed data should call build_assessment_result
+    directly.
+    """
+    return build_assessment_result(tlr_dir, timestamp).assessment
+
+
+def build_assessment_result(tlr_dir, timestamp):
+    """Build an AssessmentOutcome for one TLR directory.
 
     Mirrors the per-TLR computation in the original process_results_directory(),
-    but RETURNS the structured object instead of writing RTF. Returns None if the
-    directory has no usable summary files (caller decides how to report).
+    but RETURNS the structured object instead of writing RTF.
     """
-    summary_files = glob.glob(
-        os.path.join(tlr_dir, 'summary_results_Simulation-Configuration-TLR*.csv')
-    )
+    summary_files = find_summary_files(tlr_dir)
     if not summary_files:
         print(f"  Warning: No summary results files found in {tlr_dir}")
-        return None
+        return AssessmentOutcome(
+            None, 'empty',
+            f"no {SUMMARY_RESULTS_GLOB} files found (nothing ran in this directory)",
+        )
 
-    simulation_id = extract_simulation_id(summary_files[0])
+    usable_files, unusable_files = classify_summary_files(tlr_dir)
+    if not usable_files:
+        # Every file unusable used to render a COMPLETE document with every metric
+        # 'NA'/0 and "Data not available for outlier analysis." -- a regulatory
+        # document asserting near-baseline results from data that could not be
+        # read. It is a malformed directory, and produces no document.
+        print(f"  Error: {len(unusable_files)} summary results file(s) present in "
+              f"{tlr_dir}, none usable")
+        return AssessmentOutcome(
+            None, 'malformed',
+            f"{len(unusable_files)} summary results file(s) present, none usable: "
+            f"unreadable or missing required column(s) "
+            f"{list(REQUIRED_SUMMARY_COLUMNS)}",
+        )
+
+    simulation_id = resolve_simulation_id(summary_files)
     if not simulation_id:
-        print(f"  Error: Could not extract simulation ID from {summary_files[0]}")
-        return None
+        print(f"  Error: Could not extract simulation ID from any summary results "
+              f"file in {tlr_dir}")
+        return AssessmentOutcome(
+            None, 'malformed',
+            "could not extract a TLR simulation ID from any summary results filename",
+        )
 
-    profile_count = count_profiles(tlr_dir)
+    profile_count = len(summary_files)
+    usable_profile_count = len(usable_files)
 
     # Catastrophic (4->5) assessment.
     severity_4_sim_ids = identify_severity_4_hypoglycemia(tlr_dir)
@@ -664,7 +869,7 @@ def build_assessment(tlr_dir, timestamp):
     # renderers never re-read the directory or re-derive the branch.
     outlier_list, outlier_status = detect_outliers(tlr_dir, assessment_results)
 
-    return SeverityAssessment(
+    assessment = SeverityAssessment(
         simulation_id=simulation_id,
         subdirectory_name=os.path.basename(tlr_dir),
         timestamp=timestamp,
@@ -673,4 +878,6 @@ def build_assessment(tlr_dir, timestamp):
         catastrophic_findings=catastrophic_findings,
         outlier_findings=outlier_list,
         outlier_status=outlier_status,
+        usable_profile_count=usable_profile_count,
     )
+    return AssessmentOutcome(assessment, 'ok')

--- a/post_processing/severity_model.py
+++ b/post_processing/severity_model.py
@@ -211,7 +211,7 @@ class SeverityAssessment:
     stages: dict                    # stage -> StageResult
     catastrophic_findings: list = field(default_factory=list)   # list[CatastrophicFinding]
     outlier_findings: list = field(default_factory=list)        # list[OutlierFinding]
-    # 'ok' | 'no_data' | 'malformed_data' | 'single_profile'
+    # 'ok' | 'no_data' | 'malformed_data' | 'incomplete_stages' | 'single_profile'
     outlier_status: str = 'ok'
     # M: how many of the N files could actually contribute a value. None means
     # "not measured" and is treated as M == N by consumers, so an object built by
@@ -613,19 +613,18 @@ def detect_outliers(tlr_dir, severity_updates=None):
         (list[OutlierFinding], status_str)
         status_str is one of:
           'ok'                -> findings list is authoritative (may be empty)
-          'no_data'           -> the data needed for the comparison is not present
+          'no_data'           -> no per-profile results exist to compare
           'malformed_data'    -> data IS present but unreadable/missing a required
                                  column, so the analysis was not performed
+          'incomplete_stages' -> profiles exist and parse, but none carries results
+                                 for all three stages, so there is nothing to
+                                 compare like-for-like
           'single_profile'    -> only one profile, outliers not meaningful
 
-    'no_data' used to cover both absent and malformed input, which the renderer
-    then reported as "Data not available" -- a regulatory document asserting the
-    data was missing when in fact it was corrupt. The two are now separate.
-
-    Note: a directory whose profiles parse but where no profile is complete across
-    all three stages still reports 'no_data' -- the data needed for the comparison
-    genuinely is not available. That third condition is deliberately not split out
-    here (TRSET-28 Decision B).
+    'no_data' used to cover all three of absent, malformed and incomplete input,
+    which the renderer then reported as "Data not available" -- a regulatory
+    document asserting the data was missing when it was in fact corrupt, or real but
+    thin. All three are now separate, and only genuine absence keeps that sentence.
 
     This is the detection half only. Rendering the RTF/GUI text from these
     findings lives in the consumer (create_severity_summary.render_*).
@@ -653,7 +652,11 @@ def detect_outliers(tlr_dir, severity_updates=None):
         print("  Summary results data present but unusable; check data configuration.")
         return ([], 'malformed_data')
 
-    if profile_data is None:
+    if not profile_data:
+        # Either no summary files at all (get_profile_metrics said 'no_data', and
+        # profile_data is None), or files whose names identify no profile -- an
+        # aggregate-only directory with no '*_profile.csv'. Either way there are no
+        # per-profile results in existence to compare, which is what 'no_data' means.
         print("  Necessary data not present; check configurations.")
         return ([], 'no_data')
 
@@ -664,8 +667,16 @@ def detect_outliers(tlr_dir, severity_updates=None):
     }
 
     if len(complete_profiles) == 0:
-        print("  Necessary data not present; check configurations.")
-        return ([], 'no_data')
+        # Profiles DO exist and parsed; none carries results for all three stages,
+        # so there is no like-for-like comparison to make. Distinct from 'no_data'
+        # (nothing to compare) and from 'malformed_data' (unreadable): this data is
+        # readable and real, just too thin for a cross-stage comparison. Reporting it
+        # as absent hid a recoverable configuration problem -- a run that produced
+        # only some stages -- behind the same sentence as a missing directory.
+        print(f"  No profile in {tlr_dir} has results for all three evaluation "
+              f"stages ({len(profile_data)} profile(s) found); "
+              f"outlier comparison needs at least two that do.")
+        return ([], 'incomplete_stages')
 
     if len(complete_profiles) == 1:
         return ([], 'single_profile')

--- a/post_processing/test_create_severity_summary.py
+++ b/post_processing/test_create_severity_summary.py
@@ -673,3 +673,76 @@ class TestSkipReasonsDistinguishEmptyFromMalformed:
         monkeypatch.setattr(sys, "argv", ["create_severity_summary.py", str(tmp_path)])
 
         assert main() == 1
+
+
+_INCOMPLETE_STAGES_LINE = (
+    "Outlier analysis not performed: no profile has results for all "
+    "three evaluation stages."
+)
+
+
+class TestRenderOutlierResultsIncompleteStages:
+    """TRSET-28 Decision B: the third condition that hid inside 'no_data'."""
+
+    def test_incomplete_stages_gets_its_own_text(self):
+        assert render_outlier_results([], "incomplete_stages") == _INCOMPLETE_STAGES_LINE
+
+    def test_it_does_not_claim_the_data_was_unavailable(self):
+        assert "not available" not in render_outlier_results([], "incomplete_stages")
+
+    def test_it_is_distinct_from_the_malformed_text(self):
+        """Both are "present but unusable for this analysis" -- for different, and
+        differently actionable, reasons."""
+        assert render_outlier_results([], "incomplete_stages") != render_outlier_results(
+            [], "malformed_data"
+        )
+
+    def test_the_three_degraded_statuses_render_three_different_sentences(self):
+        rendered = {
+            render_outlier_results([], status)
+            for status in ("no_data", "malformed_data", "incomplete_stages")
+        }
+        assert len(rendered) == 3
+
+    def test_an_unknown_status_still_falls_through_to_the_findings_text(self):
+        """Defensive: a status this renderer does not know must not silently render
+        a degraded sentence. With no findings it reports none found."""
+        assert render_outlier_results([], "some_future_status") == _CLEAN_OUTLIER_LINE
+
+
+class TestRenderedIncompleteStagesDocument:
+    """The whole path: partial-stage CSVs -> assessment -> rendered document."""
+
+    _OUTLIER_COLUMNS = [
+        "sim_id", "percent_values_ge_70_le_180", "percent_cgm_lt_54",
+        "percent_cgm_gt_180", "lbgi_risk_score", "dka_risk_score",
+    ]
+
+    @pytest.fixture
+    def incomplete_rtf(self, tmp_path):
+        tlr = str(tmp_path)
+        for profile in ("median", "adolescent"):
+            rows = [
+                (f"{stem}_{profile}", 80.0, 1.0, 20.0, 1, 0)
+                for stem in ("pre-Loop_NoMitigations_t1", "pre-noLoop_t1")
+            ]  # no post- row -> no profile is stage-complete
+            _write_summary_csv(tlr, profile, rows, columns=self._OUTLIER_COLUMNS)
+        assessment = build_assessment(tlr, "2026-08-06T00:00:00")
+        assert assessment is not None, "readable data must still produce a document"
+        return render_rtf(assessment)
+
+    def test_the_outlier_section_names_the_missing_stages(self, incomplete_rtf):
+        assert _INCOMPLETE_STAGES_LINE in incomplete_rtf
+
+    def test_it_does_not_say_the_data_was_unavailable(self, incomplete_rtf):
+        assert "Data not available for outlier analysis." not in incomplete_rtf
+
+    def test_the_count_line_is_clean_because_both_files_are_usable(self, incomplete_rtf):
+        """Thin data is not malformed data: M == N, so finding 3's line is unchanged."""
+        assert "2 virtual patient profiles aggregated for this summary." in incomplete_rtf
+
+    def test_the_missing_stage_renders_na_not_a_blank_cell(self, incomplete_rtf):
+        rows = _table_rows(incomplete_rtf)
+        post_row = next(row for row in rows[1:] if row[0] == "Post-mitigation")
+        tir_index = rows[0].index("TIR % (70 - 180 mg/dL)")
+        assert post_row[tir_index] == "NA"

--- a/post_processing/test_create_severity_summary.py
+++ b/post_processing/test_create_severity_summary.py
@@ -29,7 +29,7 @@ from create_severity_summary import (
     render_rtf,
     round_half_up,
 )
-from severity_model import build_assessment
+from severity_model import build_assessment, OutlierFinding
 
 
 class TestRoundHalfUp:
@@ -600,9 +600,16 @@ class TestRenderedDegradedPath:
             "1 summary results file could not be read."
         ) in partial_rtf
 
-    def test_the_outlier_section_says_unreadable_not_unavailable(self, partial_rtf):
-        assert _MALFORMED_OUTLIER_LINE in partial_rtf
+    def test_the_outlier_analysis_runs_over_the_readable_profiles(self, partial_rtf):
+        """Decision C: the excluded file used to abandon outlier analysis for the
+        whole directory, rendering the malformed sentence. The two readable profiles
+        are now compared, and the section scopes its claim instead."""
+        assert _MALFORMED_OUTLIER_LINE not in partial_rtf
         assert "Data not available for outlier analysis." not in partial_rtf
+        assert "No outlier profiles exist." in partial_rtf
+
+    def test_the_outlier_section_scopes_its_claim_to_what_was_analyzed(self, partial_rtf):
+        assert "This analysis covered 2 of 3 profiles; 1 could not be read." in partial_rtf
 
     def test_the_table_still_renders(self, partial_rtf):
         """A partial document is still a complete document."""
@@ -746,3 +753,55 @@ class TestRenderedIncompleteStagesDocument:
         post_row = next(row for row in rows[1:] if row[0] == "Post-mitigation")
         tir_index = rows[0].index("TIR % (70 - 180 mg/dL)")
         assert post_row[tir_index] == "NA"
+
+
+class TestOutlierScopeSentence:
+    """Decision C: an outlier claim over a subset must say so.
+
+    The count line above the section already reports the drop, but the Outlier
+    Results sentences are absolute claims read (and quoted) on their own.
+    """
+
+    _CLEAN_FINDING = OutlierFinding("pre", "sensitive", "Hypoglycemia", 4.0, 2.0)
+
+    def test_no_scope_sentence_when_nothing_was_excluded(self):
+        assert render_outlier_results([], "ok", 3, 3) == _CLEAN_OUTLIER_LINE
+
+    def test_no_scope_sentence_when_counts_are_unknown(self):
+        """Both default to None, so an older caller renders exactly as before."""
+        assert render_outlier_results([], "ok") == _CLEAN_OUTLIER_LINE
+        assert render_outlier_results([], "ok", None, None) == _CLEAN_OUTLIER_LINE
+
+    def test_the_no_outliers_claim_is_scoped(self):
+        assert render_outlier_results([], "ok", 3, 2) == (
+            _CLEAN_OUTLIER_LINE
+            + " This analysis covered 2 of 3 profiles; 1 could not be read."
+        )
+
+    def test_a_findings_claim_is_scoped_too(self):
+        rendered = render_outlier_results([self._CLEAN_FINDING], "ok", 4, 2)
+
+        assert rendered.startswith("Outlier profile exists.")
+        assert rendered.endswith(
+            " This analysis covered 2 of 4 profiles; 2 could not be read."
+        )
+
+    def test_single_profile_is_scoped_because_it_asserts_a_count(self):
+        """'Only one profile present' would be false when three were present and two
+        were excluded."""
+        rendered = render_outlier_results([], "single_profile", 3, 1)
+
+        assert rendered == (
+            "Only one profile present, so outliers are not relevant."
+            " This analysis covered 1 of 3 profiles; 2 could not be read."
+        )
+
+    def test_statuses_that_assert_nothing_are_not_scoped(self):
+        """These already say the analysis did not happen, and why; appending a scope
+        sentence would only repeat the count line."""
+        for status in ("no_data", "malformed_data", "incomplete_stages"):
+            assert "This analysis covered" not in render_outlier_results([], status, 3, 1)
+
+    def test_a_count_above_the_total_is_not_scoped(self):
+        """Defensive: never render 'more analyzed than present'."""
+        assert render_outlier_results([], "ok", 2, 3) == _CLEAN_OUTLIER_LINE

--- a/post_processing/test_create_severity_summary.py
+++ b/post_processing/test_create_severity_summary.py
@@ -24,6 +24,8 @@ from create_severity_summary import (
     TABLE_CELL_STOPS,
     calculate_integer_averages,
     process_results_directory,
+    render_outlier_results,
+    render_profile_count,
     render_rtf,
     round_half_up,
 )
@@ -470,3 +472,204 @@ class TestRtfOutputUnchanged:
         assessment = build_assessment(tlr_dir, _RUN_TIMESTAMP)
         with open(result.written[0]) as fh:
             assert fh.read() == render_rtf(assessment)
+
+
+# =============================================================================
+# TRSET-28 -- the two rendered strings that change, and only on degraded paths
+# =============================================================================
+
+# The verdict-input columns. Dropping them makes a file unusable; the fixture
+# below is how a "present but unreadable" profile is simulated.
+_MISSING_REQUIRED_COLUMNS = [
+    "sim_id", "percent_values_ge_70_le_180", "percent_cgm_lt_54",
+]
+
+# The clean-path strings, pinned VERBATIM. TestRtfOutputUnchanged compares the
+# written file against the renderer's own output, so it is a self-consistency
+# check that would pass even if every string here changed. These are the actual
+# byte-identity guard for the two lines TRSET-28 touches.
+_CLEAN_PROFILE_COUNT_LINE = "2 virtual patient profiles aggregated for this summary."
+_CLEAN_OUTLIER_LINE = (
+    "No outlier profiles exist. All results are within 1 severity level of one another."
+)
+_MALFORMED_OUTLIER_LINE = (
+    "Outlier analysis not performed: profile data is present but could not be read. "
+    "Check data configuration."
+)
+
+
+def _malformed_tlr_dir(run_dir, name="TLR-500-malformed"):
+    """A TLR directory whose only summary CSV cannot contribute a value."""
+    tlr_dir = os.path.join(run_dir, name)
+    os.makedirs(tlr_dir)
+    _write_summary_csv(tlr_dir, "median", _PROFILE_A_ROWS,
+                       columns=_MISSING_REQUIRED_COLUMNS)
+    return tlr_dir
+
+
+def _partial_tlr_dir(run_dir, name="TLR-400-partial"):
+    """Two usable profiles plus one unusable file: M == 2, N == 3."""
+    tlr_dir = _usable_tlr_dir(run_dir, name)
+    _write_summary_csv(tlr_dir, "broken", _PROFILE_A_ROWS,
+                       columns=_MISSING_REQUIRED_COLUMNS)
+    return tlr_dir
+
+
+class TestRenderOutlierResults:
+    """Finding 2: malformed input must not render as absent input."""
+
+    def test_malformed_data_gets_its_own_text(self):
+        assert render_outlier_results([], "malformed_data") == _MALFORMED_OUTLIER_LINE
+
+    def test_malformed_text_does_not_claim_the_data_was_unavailable(self):
+        """The defect: a corrupt CSV produced a document asserting absence."""
+        assert "not available" not in render_outlier_results([], "malformed_data")
+
+    def test_no_data_text_is_unchanged(self):
+        assert render_outlier_results([], "no_data") == "Data not available for outlier analysis."
+
+    def test_single_profile_text_is_unchanged(self):
+        assert render_outlier_results([], "single_profile") == (
+            "Only one profile present, so outliers are not relevant."
+        )
+
+    def test_ok_with_no_findings_text_is_unchanged(self):
+        assert render_outlier_results([], "ok") == _CLEAN_OUTLIER_LINE
+
+
+class TestRenderProfileCount:
+    """Finding 3: M of N, and byte-identical when M == N."""
+
+    def test_m_equals_n_is_the_original_sentence(self):
+        assert render_profile_count(2, 2) == _CLEAN_PROFILE_COUNT_LINE
+
+    def test_unmeasured_count_is_the_original_sentence(self):
+        """usable=None means 'not measured' -- an older assessment renders as before."""
+        assert render_profile_count(2, None) == _CLEAN_PROFILE_COUNT_LINE
+        assert render_profile_count(2) == _CLEAN_PROFILE_COUNT_LINE
+
+    def test_one_dropped_file_is_singular(self):
+        assert render_profile_count(3, 2) == (
+            "2 of 3 virtual patient profiles aggregated for this summary. "
+            "1 summary results file could not be read."
+        )
+
+    def test_two_dropped_files_are_plural(self):
+        assert render_profile_count(4, 2) == (
+            "2 of 4 virtual patient profiles aggregated for this summary. "
+            "2 summary results files could not be read."
+        )
+
+    def test_a_count_above_n_degrades_to_the_original_sentence(self):
+        """Defensive: never render 'more usable than present'."""
+        assert render_profile_count(2, 3) == _CLEAN_PROFILE_COUNT_LINE
+
+
+class TestRenderedCleanPathIsPinned:
+    """The clean path (M == N, well-formed data) renders today's exact strings."""
+
+    def test_profile_count_line_is_verbatim(self, rendered_rtf):
+        assert _CLEAN_PROFILE_COUNT_LINE in rendered_rtf
+
+    def test_outlier_line_is_verbatim(self, rendered_rtf):
+        assert _CLEAN_OUTLIER_LINE in rendered_rtf
+
+    def test_no_degraded_wording_leaks_onto_the_clean_path(self, rendered_rtf):
+        assert "of 2 virtual patient profiles" not in rendered_rtf
+        assert "could not be read" not in rendered_rtf
+        assert "Outlier analysis not performed" not in rendered_rtf
+
+
+class TestRenderedDegradedPath:
+    """A document with a dropped file carries both new strings."""
+
+    @pytest.fixture
+    def partial_rtf(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
+        _write_summary_csv(tlr, "adolescent", _PROFILE_B_ROWS)
+        _write_summary_csv(tlr, "broken", _PROFILE_A_ROWS,
+                           columns=_MISSING_REQUIRED_COLUMNS)
+        assessment = build_assessment(tlr, "2026-08-06T00:00:00")
+        assert assessment is not None, "0 < M < N must still produce a document"
+        return render_rtf(assessment)
+
+    def test_the_count_line_names_both_numbers(self, partial_rtf):
+        assert (
+            "2 of 3 virtual patient profiles aggregated for this summary. "
+            "1 summary results file could not be read."
+        ) in partial_rtf
+
+    def test_the_outlier_section_says_unreadable_not_unavailable(self, partial_rtf):
+        assert _MALFORMED_OUTLIER_LINE in partial_rtf
+        assert "Data not available for outlier analysis." not in partial_rtf
+
+    def test_the_table_still_renders(self, partial_rtf):
+        """A partial document is still a complete document."""
+        assert len(_table_rows(partial_rtf)) == 4
+
+
+class TestSkipReasonsDistinguishEmptyFromMalformed:
+    """Finding 1 at the reporting boundary: both used to be one shared string."""
+
+    def test_an_empty_directory_reports_empty(self, tmp_path):
+        _write_metadata(str(tmp_path))
+        os.makedirs(os.path.join(str(tmp_path), "TLR-000-empty"))
+
+        result = process_results_directory(str(tmp_path))
+
+        assert "empty" in result.skipped[0][1]
+
+    def test_a_malformed_directory_reports_malformed(self, tmp_path):
+        _write_metadata(str(tmp_path))
+        _malformed_tlr_dir(str(tmp_path))
+
+        result = process_results_directory(str(tmp_path))
+
+        assert result.written == []
+        assert "malformed" in result.skipped[0][1]
+
+    def test_the_two_reasons_are_not_the_same_string(self, tmp_path):
+        _write_metadata(str(tmp_path))
+        os.makedirs(os.path.join(str(tmp_path), "TLR-000-empty"))
+        _malformed_tlr_dir(str(tmp_path))
+
+        reasons = {reason for _, reason in process_results_directory(str(tmp_path)).skipped}
+
+        assert len(reasons) == 2
+
+    def test_a_malformed_directory_writes_no_document(self, tmp_path):
+        """It used to write a complete document with every metric NA/0."""
+        _write_metadata(str(tmp_path))
+        tlr_dir = _malformed_tlr_dir(str(tmp_path))
+
+        process_results_directory(str(tmp_path))
+
+        assert [f for f in os.listdir(tlr_dir) if f.endswith(".rtf")] == []
+
+    def test_one_malformed_directory_does_not_cost_the_others(self, tmp_path):
+        """TRSET-27's fatal-vs-partial split: malformed is still per-directory."""
+        _write_metadata(str(tmp_path))
+        usable = _usable_tlr_dir(str(tmp_path))
+        malformed = _malformed_tlr_dir(str(tmp_path))
+
+        result = process_results_directory(str(tmp_path))
+
+        assert [os.path.dirname(p) for p in result.written] == [usable]
+        assert [d for d, _ in result.skipped] == [malformed]
+
+    def test_a_partially_usable_directory_is_written_not_skipped(self, tmp_path):
+        _write_metadata(str(tmp_path))
+        partial = _partial_tlr_dir(str(tmp_path))
+
+        result = process_results_directory(str(tmp_path))
+
+        assert [os.path.dirname(p) for p in result.written] == [partial]
+        assert result.skipped == []
+
+    def test_a_malformed_only_run_exits_nonzero(self, tmp_path, monkeypatch):
+        _write_metadata(str(tmp_path))
+        _malformed_tlr_dir(str(tmp_path))
+        monkeypatch.setattr(sys, "argv", ["create_severity_summary.py", str(tmp_path)])
+
+        assert main() == 1

--- a/post_processing/test_severity_model.py
+++ b/post_processing/test_severity_model.py
@@ -740,3 +740,159 @@ class TestOptionalColumnIsNotCalledMalformed:
         extract_metric_data(tlr, "lbgi_risk_score")
 
         assert "malformed" in capsys.readouterr().out
+
+
+# =============================================================================
+# Hyperglycemia zero case in the outlier path (was: KNOWN INCONSISTENCY)
+# =============================================================================
+
+# detect_outliers computed its own TAR->score mapping without a zero case, so a
+# profile with TAR == 0.0 scored 1 where calculate_hyperglycemia_score gives 0.
+# Correcting it moves such a profile from the 'Hyperglycemia' harm group to
+# baseline -- and the zero-TAR outlier check keyed on that group, so the naive fix
+# would have stopped flagging the cleanest profiles. These tests pin BOTH halves:
+# the score is now the module's single mapping, AND the check still fires.
+
+_OUTLIER_COLUMNS = [
+    "sim_id", "percent_values_ge_70_le_180", "percent_cgm_lt_54",
+    "percent_cgm_gt_180", "lbgi_risk_score", "dka_risk_score",
+]
+_OUTLIER_STAGE_STEMS = (
+    "pre-Loop_NoMitigations_t1", "pre-noLoop_t1", "post-Loop_WithMitigations_t1",
+)
+
+
+def _write_outlier_profile(directory, profile, tar, lbgi, dka):
+    """A profile complete across all three stages, every stage carrying the same
+    (tar, lbgi, dka) -- so a finding appears once per stage and the assertions do
+    not depend on which stage is which."""
+    rows = [
+        (f"{stem}_{profile}", 80.0, 1.0, tar, lbgi, dka)
+        for stem in _OUTLIER_STAGE_STEMS
+    ]
+    return _write_summary_csv(directory, profile, rows, columns=_OUTLIER_COLUMNS)
+
+
+def _hyper_outliers(tlr_dir):
+    findings, status = detect_outliers(tlr_dir)
+    assert status == "ok", f"expected usable data, got {status!r}"
+    return [f for f in findings if f.harm_type == "Hyperglycemia"]
+
+
+class TestHyperglycemiaScoreHasOneMapping:
+    """The outlier path no longer carries its own TAR->score mapping."""
+
+    def test_the_outlier_path_calls_the_shared_mapping(self):
+        """Asserted over the parsed AST, not the source text: the docstring quotes
+        the old inline expression verbatim, so a substring check would pass or fail
+        on prose rather than on code."""
+        import ast
+        import inspect
+
+        tree = ast.parse(inspect.getsource(detect_outliers))
+        called = {
+            node.func.id for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+
+        assert "calculate_hyperglycemia_score" in called
+
+    def test_baseline_label_is_named_once(self):
+        """detect_outliers has to reason about the baseline GROUP, so the label and
+        the string determine_harm_and_severity returns must not drift apart."""
+        assert determine_harm_and_severity(0, 0, 0) == (severity_model.BASELINE_HARM, "0")
+
+    def test_true_zero_tar_scores_zero_on_the_outlier_path_too(self):
+        """The mapping the outlier path now shares: 0 only if TAR is truly 0."""
+        assert calculate_hyperglycemia_score(0.0) == 0
+        assert calculate_hyperglycemia_score(5.0) == 1
+        assert calculate_hyperglycemia_score(20.0) == 2
+
+
+class TestZeroTarOutlierStillFlagged:
+    """The regression the naive score fix would have introduced."""
+
+    def test_flagged_when_the_zero_profile_has_no_hypo_or_dka_risk(self, tmp_path):
+        """lbgi=0/dka=0/TAR=0 is now baseline, not Hyperglycemia. Keying the check
+        on the Hyperglycemia group alone would silently drop this finding -- the
+        cleanest profile among high-TAR peers is exactly the one worth flagging."""
+        tlr = str(tmp_path)
+        _write_outlier_profile(tlr, "zero", tar=0.0, lbgi=0, dka=0)
+        _write_outlier_profile(tlr, "highA", tar=20.0, lbgi=0, dka=0)
+        _write_outlier_profile(tlr, "highB", tar=25.0, lbgi=0, dka=0)
+
+        found = _hyper_outliers(tlr)
+
+        assert {f.profile for f in found} == {"zero"}
+        assert sorted(f.stage for f in found) == ["no_loop", "post", "pre"]
+        assert all(f.value == 0.0 for f in found)
+
+    def test_flagged_when_the_zero_profile_stays_in_the_hyperglycemia_group(self, tmp_path):
+        """lbgi=1 keeps it out of baseline, so this half worked before and after."""
+        tlr = str(tmp_path)
+        _write_outlier_profile(tlr, "zero", tar=0.0, lbgi=1, dka=0)
+        _write_outlier_profile(tlr, "highA", tar=20.0, lbgi=1, dka=0)
+        _write_outlier_profile(tlr, "highB", tar=25.0, lbgi=1, dka=0)
+
+        assert {f.profile for f in _hyper_outliers(tlr)} == {"zero"}
+
+    def test_the_reported_median_is_of_the_non_zero_profiles(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_outlier_profile(tlr, "zero", tar=0.0, lbgi=0, dka=0)
+        _write_outlier_profile(tlr, "highA", tar=20.0, lbgi=0, dka=0)
+        _write_outlier_profile(tlr, "highB", tar=30.0, lbgi=0, dka=0)
+
+        assert {f.comparison_median for f in _hyper_outliers(tlr)} == {30.0}
+
+    def test_several_zero_profiles_are_each_flagged(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_outlier_profile(tlr, "zeroA", tar=0.0, lbgi=0, dka=0)
+        _write_outlier_profile(tlr, "zeroB", tar=0.0, lbgi=0, dka=0)
+        _write_outlier_profile(tlr, "high", tar=20.0, lbgi=0, dka=0)
+
+        assert {f.profile for f in _hyper_outliers(tlr)} == {"zeroA", "zeroB"}
+
+    def test_not_flagged_when_a_peer_is_not_high(self, tmp_path):
+        """Unchanged gate: every non-zero profile must be >= 12.0 TAR."""
+        tlr = str(tmp_path)
+        _write_outlier_profile(tlr, "zero", tar=0.0, lbgi=0, dka=0)
+        _write_outlier_profile(tlr, "mid", tar=5.0, lbgi=0, dka=0)
+        _write_outlier_profile(tlr, "high", tar=20.0, lbgi=0, dka=0)
+
+        assert _hyper_outliers(tlr) == []
+
+    def test_not_flagged_when_no_profile_is_at_zero(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_outlier_profile(tlr, "a", tar=15.0, lbgi=0, dka=0)
+        _write_outlier_profile(tlr, "b", tar=20.0, lbgi=0, dka=0)
+
+        assert _hyper_outliers(tlr) == []
+
+    def test_a_zero_tar_profile_with_hypo_risk_is_not_swept_in(self, tmp_path):
+        """The check spans Hyperglycemia + baseline only. A TAR == 0 profile whose
+        LBGI puts it in the Hypoglycemia group was never compared on the
+        hyperglycemia axis, and still is not."""
+        tlr = str(tmp_path)
+        _write_outlier_profile(tlr, "hypoZero", tar=0.0, lbgi=4, dka=0)
+        _write_outlier_profile(tlr, "highA", tar=20.0, lbgi=0, dka=0)
+        _write_outlier_profile(tlr, "highB", tar=25.0, lbgi=0, dka=0)
+
+        assert _hyper_outliers(tlr) == []
+
+    def test_hypoglycemia_outliers_are_unaffected(self, tmp_path):
+        """The score fix touches only the hyperglycemia axis.
+
+        lbgi=2, not 1, for the peers: determine_harm_and_severity sends lbgi<=1 with
+        dka==0 to Hyperglycemia, so lbgi=1 peers would never form a Hypoglycemia
+        group to be an outlier within.
+        """
+        tlr = str(tmp_path)
+        _write_outlier_profile(tlr, "severe", tar=20.0, lbgi=4, dka=0)
+        _write_outlier_profile(tlr, "mildA", tar=20.0, lbgi=2, dka=0)
+        _write_outlier_profile(tlr, "mildB", tar=20.0, lbgi=2, dka=0)
+
+        findings, status = detect_outliers(tlr)
+
+        assert status == "ok"
+        hypo = [f for f in findings if f.harm_type == "Hypoglycemia"]
+        assert {f.profile for f in hypo} == {"severe"}

--- a/post_processing/test_severity_model.py
+++ b/post_processing/test_severity_model.py
@@ -381,7 +381,7 @@ class TestSummaryResultsGlobIsSharedAndLoose:
         assert count_profiles(tlr) == 2
         assert count_usable_profiles(tlr) == 2
         assert extract_metric_data(tlr, "lbgi_risk_score")["pre"] == [3, 3]
-        assert set(get_profile_metrics(tlr)[0]) == {"median", "adolescent"}
+        assert set(get_profile_metrics(tlr).profiles) == {"median", "adolescent"}
         assert identify_severity_4_hypoglycemia(tlr) == {}  # no score-4 rows, but it read them
 
         outcome = build_assessment_result(tlr, "2026-08-06T00:00:00")
@@ -646,51 +646,101 @@ class TestClassifySummaryFiles:
         assert classify_summary_files(str(tmp_path)) == ([], [])
 
 
-class TestGetProfileMetricsStatus:
-    """Finding 2 at the source: absent and malformed are now separate."""
+class TestGetProfileMetrics:
+    """Finding 2 at the source, plus Decision C: an unreadable file is EXCLUDED and
+    named rather than discarding every readable profile with it."""
 
-    def test_no_files_is_no_data(self, tmp_path):
-        assert get_profile_metrics(str(tmp_path)) == (None, "no_data")
+    def test_no_files_means_no_files_present(self, tmp_path):
+        metrics = get_profile_metrics(str(tmp_path))
 
-    def test_missing_required_columns_is_malformed(self, tmp_path):
+        assert metrics.files_present is False
+        assert metrics.profiles == {}
+        assert metrics.excluded == []
+
+    def test_a_file_missing_required_columns_is_excluded_and_named(self, tmp_path):
         tlr = str(tmp_path)
-        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS,
-                           columns=_MISSING_REQUIRED_COLUMNS)
+        broken = _write_summary_csv(tlr, "median", _PROFILE_A_ROWS,
+                                    columns=_MISSING_REQUIRED_COLUMNS)
 
-        profile_data, status = get_profile_metrics(tlr)
+        metrics = get_profile_metrics(tlr)
 
-        assert status == "malformed_data"
-        assert profile_data is None
+        assert metrics.files_present is True
+        assert metrics.profiles == {}
+        assert metrics.excluded == [broken]
 
-    def test_an_unreadable_file_is_malformed(self, tmp_path):
+    def test_an_unreadable_file_is_excluded_and_named(self, tmp_path):
         tlr = str(tmp_path)
-        _write_unreadable_csv(tlr, "median")
+        broken = _write_unreadable_csv(tlr, "median")
 
-        assert get_profile_metrics(tlr)[1] == "malformed_data"
+        assert get_profile_metrics(tlr).excluded == [broken]
 
-    def test_clean_data_is_ok(self, tmp_path):
+    def test_clean_data_yields_its_profiles_and_excludes_nothing(self, tmp_path):
         tlr = str(tmp_path)
         _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
 
-        profile_data, status = get_profile_metrics(tlr)
+        metrics = get_profile_metrics(tlr)
 
-        assert status == "ok"
-        assert set(profile_data) == {"median"}
+        assert set(metrics.profiles) == {"median"}
+        assert metrics.excluded == []
+
+    def test_one_bad_file_no_longer_discards_the_good_ones(self, tmp_path):
+        """The Decision C change. This used to return None for the whole directory,
+        so a single malformed profile cost the outlier analysis of every valid one."""
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
+        _write_summary_csv(tlr, "adolescent", _PROFILE_B_ROWS)
+        broken = _write_summary_csv(tlr, "broken", _PROFILE_A_ROWS,
+                                    columns=_MISSING_REQUIRED_COLUMNS)
+
+        metrics = get_profile_metrics(tlr)
+
+        assert set(metrics.profiles) == {"median", "adolescent"}
+        assert metrics.excluded == [broken]
+
+    def test_an_excluded_file_leaves_no_partial_profile_behind(self, tmp_path):
+        """Profiles are published only once fully built, so an excluded file cannot
+        appear in `profiles` with some stages filled in."""
+        tlr = str(tmp_path)
+        _write_unreadable_csv(tlr, "broken")
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
+
+        metrics = get_profile_metrics(tlr)
+
+        assert "broken" not in metrics.profiles
+        assert set(metrics.profiles) == {"median"}
 
 
 class TestDetectOutliersStatus:
     """Finding 2 at the boundary the renderer reads."""
 
-    def test_malformed_data_is_not_reported_as_no_data(self, tmp_path):
+    def test_every_profile_file_unreadable_is_malformed_not_no_data(self, tmp_path):
+        """'malformed_data' now means NOTHING survived exclusion (Decision C): one
+        bad file among good ones is excluded and the good ones analyzed."""
         tlr = str(tmp_path)
-        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
-        _write_summary_csv(tlr, "broken", _PROFILE_A_ROWS,
+        _write_summary_csv(tlr, "brokenA", _PROFILE_A_ROWS,
+                           columns=_MISSING_REQUIRED_COLUMNS)
+        _write_summary_csv(tlr, "brokenB", _PROFILE_B_ROWS,
                            columns=_MISSING_REQUIRED_COLUMNS)
 
         findings, status = detect_outliers(tlr)
 
         assert status == "malformed_data"
         assert findings == []
+
+    def test_one_bad_file_among_good_ones_no_longer_blocks_the_analysis(self, tmp_path):
+        """Was 'malformed_data' with zero findings for the whole directory. The two
+        readable profiles are now compared, and the drop is disclosed by the
+        renderer from the assessment's usable-vs-total counts."""
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
+        _write_summary_csv(tlr, "adolescent", _PROFILE_B_ROWS)
+        _write_summary_csv(tlr, "broken", _PROFILE_A_ROWS,
+                           columns=_MISSING_REQUIRED_COLUMNS)
+
+        findings, status = detect_outliers(tlr)
+
+        assert status == "ok"
+        assert findings == []       # these two profiles simply have no outlier
 
     def test_a_genuinely_absent_directory_is_still_no_data(self, tmp_path):
         assert detect_outliers(str(tmp_path)) == ([], "no_data")
@@ -710,11 +760,31 @@ class TestDetectOutliersStatus:
 
     def test_the_status_reaches_the_assessment(self, tmp_path):
         tlr = str(tmp_path)
+        _write_summary_csv(tlr, "brokenA", _PROFILE_A_ROWS,
+                           columns=_MISSING_REQUIRED_COLUMNS)
+        _write_summary_csv(tlr, "brokenB", _PROFILE_B_ROWS,
+                           columns=_MISSING_REQUIRED_COLUMNS)
+        # A usable file with NO profile part in its name, so M >= 1 and
+        # build_assessment produces a document at all -- while leaving every
+        # per-profile file excluded. Written by hand: _write_summary_csv always
+        # appends '_<profile>_profile.csv', which would make it a valid profile.
+        aggregate = os.path.join(tlr, f"summary_results_{_NARROW_STEM}.csv")
+        with open(aggregate, "w") as fh:
+            fh.write(",".join(_SUMMARY_COLUMNS) + "\n")
+            for row in _PROFILE_A_ROWS:
+                fh.write(",".join(str(v) for v in row) + "\n")
+
+        assert build_assessment(tlr, "2026-08-06T00:00:00").outlier_status == "malformed_data"
+
+    def test_a_surviving_profile_beside_an_excluded_one_is_single_profile(self, tmp_path):
+        """One readable profile plus one excluded: there is one analyzable profile,
+        which is the single-profile case -- not 'malformed_data' as it used to be."""
+        tlr = str(tmp_path)
         _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
         _write_summary_csv(tlr, "broken", _PROFILE_A_ROWS,
                            columns=_MISSING_REQUIRED_COLUMNS)
 
-        assert build_assessment(tlr, "2026-08-06T00:00:00").outlier_status == "malformed_data"
+        assert detect_outliers(tlr)[1] == "single_profile"
 
 
 class TestOptionalColumnIsNotCalledMalformed:
@@ -947,9 +1017,11 @@ class TestIncompleteStagesIsNotReportedAsAbsent:
     def test_an_empty_directory_is_still_no_data(self, tmp_path):
         assert detect_outliers(str(tmp_path))[1] == "no_data"
 
-    def test_malformed_still_outranks_incomplete(self, tmp_path):
-        """A directory that is BOTH unreadable and thin reports the unreadability --
-        the more actionable fault, and the one that makes the rest unknowable."""
+    def test_incomplete_now_outranks_an_excluded_file(self, tmp_path):
+        """Precedence FLIPPED with Decision C, deliberately. An unreadable file no
+        longer poisons the directory -- it is excluded -- so what the reader needs to
+        know is the state of the data that REMAINS: readable, but stage-thin.
+        'malformed_data' is reserved for nothing surviving at all."""
         tlr = str(tmp_path)
         self._write_partial_stage_profile(
             tlr, "median", ("pre-Loop_NoMitigations_t1",),
@@ -957,7 +1029,7 @@ class TestIncompleteStagesIsNotReportedAsAbsent:
         _write_summary_csv(tlr, "broken", _PROFILE_A_ROWS,
                            columns=_MISSING_REQUIRED_COLUMNS)
 
-        assert detect_outliers(tlr)[1] == "malformed_data"
+        assert detect_outliers(tlr)[1] == "incomplete_stages"
 
     def test_one_complete_profile_is_still_single_profile(self, tmp_path):
         """A complete profile alongside incomplete ones is the single-profile case,

--- a/post_processing/test_severity_model.py
+++ b/post_processing/test_severity_model.py
@@ -18,14 +18,27 @@ import os
 
 import pytest
 
+import severity_model
 from severity_model import (
     build_assessment,
+    build_assessment_result,
     calculate_truncated_averages,
+    classify_summary_files,
+    count_profiles,
+    count_usable_profiles,
+    detect_outliers,
     determine_harm_and_severity,
     calculate_hyperglycemia_score,
     check_consecutive_low_values,
     classify_sim_id,
+    extract_metric_data,
+    find_summary_files,
+    get_profile_metrics,
+    identify_severity_4_hypoglycemia,
+    resolve_simulation_id,
     truncate_2dp,
+    REQUIRED_SUMMARY_COLUMNS,
+    SUMMARY_RESULTS_GLOB,
     StageResult,
     CatastrophicFinding,
     OutlierFinding,
@@ -184,10 +197,14 @@ _PROFILE_B_ROWS = [
 ]
 
 
-def _write_summary_csv(directory, profile, rows, columns=_SUMMARY_COLUMNS):
+_NARROW_STEM = "Simulation-Configuration-TLR-999-test"
+
+
+def _write_summary_csv(directory, profile, rows, columns=_SUMMARY_COLUMNS,
+                       stem=_NARROW_STEM):
     path = os.path.join(
         directory,
-        f"summary_results_Simulation-Configuration-TLR-999-test_{profile}_profile.csv",
+        f"summary_results_{stem}_{profile}_profile.csv",
     )
     with open(path, "w") as fh:
         fh.write(",".join(columns) + "\n")
@@ -303,3 +320,423 @@ class TestBuildAssessmentValueFields:
         sr = StageResult("pre", "Hypoglycemia", "3", "78.0", "4.5", "17.5", 3, 1, 2, 2)
         assert sr.lbgi_value_avg == "NA"
         assert sr.dka_index_value_avg == "NA"
+
+
+# =============================================================================
+# TRSET-28 -- silent/ambiguous failures in the post-processing layer
+# =============================================================================
+
+# Column sets for the degraded fixtures. "Required" is the verdict-input set:
+# without it a file cannot contribute to harm/severity at all. Dropping only the
+# reported metrics (TIR/TBR) or the raw values (lbgi/dka_index) leaves a file
+# perfectly usable -- that distinction is what keeps an older-format directory off
+# the malformed path.
+_MISSING_REQUIRED_COLUMNS = ["sim_id", "percent_values_ge_70_le_180", "percent_cgm_lt_54"]
+_WITHOUT_RAW_VALUE_COLUMNS = _SUMMARY_COLUMNS[:-2]
+
+
+def _write_unreadable_csv(directory, profile):
+    """A file that pandas cannot parse at all (ragged rows), not merely one with
+    the wrong columns -- the other half of 'present but unusable'."""
+    path = os.path.join(
+        directory, f"summary_results_{_NARROW_STEM}_{profile}_profile.csv"
+    )
+    with open(path, "w") as fh:
+        fh.write("a,b\n1,2,3,4,5\n")
+    return path
+
+
+class TestSummaryResultsGlobIsSharedAndLoose:
+    """Finding 4: one pattern, defined once, honored by every call site."""
+
+    def test_the_pattern_is_the_loose_one(self):
+        assert SUMMARY_RESULTS_GLOB == "summary_results_*.csv"
+
+    def test_glob_is_called_in_exactly_one_place(self):
+        """The DRY guard. Five call sites each built their own glob expression,
+        and build_assessment's disagreed with the other four."""
+        with open(severity_model.__file__) as fh:
+            source = fh.read()
+        assert source.count("glob.glob(") == 1
+
+    def test_files_are_returned_sorted(self, tmp_path):
+        """Unsorted glob order made simulation-ID resolution depend on the
+        filesystem once the pattern widened."""
+        tlr = str(tmp_path)
+        for profile in ("zebra", "alpha", "median"):
+            _write_summary_csv(tlr, profile, _PROFILE_A_ROWS)
+
+        found = find_summary_files(tlr)
+
+        assert found == sorted(found)
+        assert len(found) == 3
+
+    def test_every_helper_reads_a_loosely_named_file(self, tmp_path):
+        """A directory whose CSVs match the loose pattern but not the old narrow
+        one: previously build_assessment alone rejected it."""
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS, stem="Config-TLR-777")
+        _write_summary_csv(tlr, "adolescent", _PROFILE_B_ROWS, stem="Config-TLR-777")
+
+        assert count_profiles(tlr) == 2
+        assert count_usable_profiles(tlr) == 2
+        assert extract_metric_data(tlr, "lbgi_risk_score")["pre"] == [3, 3]
+        assert set(get_profile_metrics(tlr)[0]) == {"median", "adolescent"}
+        assert identify_severity_4_hypoglycemia(tlr) == {}  # no score-4 rows, but it read them
+
+        outcome = build_assessment_result(tlr, "2026-08-06T00:00:00")
+        assert outcome.status == "ok"
+        assert outcome.assessment.simulation_id == "TLR-777"
+
+    def test_a_narrowly_named_directory_still_works(self, tmp_path):
+        """The widening must not cost the directories that already worked."""
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
+
+        outcome = build_assessment_result(tlr, "2026-08-06T00:00:00")
+
+        assert outcome.status == "ok"
+        assert outcome.assessment.simulation_id == "TLR-999"
+
+
+class TestResolveSimulationId:
+    """Finding 4 fallout: summary_files[0] alone is no longer safe."""
+
+    def test_falls_through_to_the_first_filename_that_yields_an_id(self):
+        """Sorted first is a file with no TLR part. Reading [0] blindly would
+        return None and skip a directory that renders today."""
+        assert resolve_simulation_id([
+            "summary_results_AAA-noTLRhere_median_profile.csv",
+            "summary_results_Config-TLR-777_adolescent_profile.csv",
+        ]) == "TLR-777"
+
+    def test_none_when_no_filename_carries_a_tlr_part(self):
+        assert resolve_simulation_id([
+            "summary_results_AAA-nope_median_profile.csv",
+        ]) is None
+
+    def test_empty_input_is_none(self):
+        assert resolve_simulation_id([]) is None
+
+    def test_a_mixed_directory_resolves_rather_than_skipping(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS, stem="AAA-noTLRhere")
+        _write_summary_csv(tlr, "adolescent", _PROFILE_B_ROWS, stem="Config-TLR-777")
+
+        outcome = build_assessment_result(tlr, "2026-08-06T00:00:00")
+
+        assert outcome.status == "ok"
+        assert outcome.assessment.simulation_id == "TLR-777"
+
+
+class TestAssessmentOutcomeDistinguishesEmptyFromMalformed:
+    """Finding 1: the two conditions used to collapse into a bare None."""
+
+    def test_empty_directory_is_empty(self, tmp_path):
+        outcome = build_assessment_result(str(tmp_path), "2026-08-06T00:00:00")
+
+        assert outcome.status == "empty"
+        assert outcome.assessment is None
+        assert outcome.detail
+
+    def test_all_files_unusable_is_malformed_not_empty(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS,
+                           columns=_MISSING_REQUIRED_COLUMNS)
+
+        outcome = build_assessment_result(tlr, "2026-08-06T00:00:00")
+
+        assert outcome.status == "malformed"
+        assert outcome.assessment is None
+
+    def test_unreadable_file_is_malformed_not_empty(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_unreadable_csv(tlr, "median")
+
+        outcome = build_assessment_result(tlr, "2026-08-06T00:00:00")
+
+        assert outcome.status == "malformed"
+
+    def test_unresolvable_simulation_id_is_malformed(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS, stem="AAA-noTLRhere")
+
+        outcome = build_assessment_result(tlr, "2026-08-06T00:00:00")
+
+        assert outcome.status == "malformed"
+        assert outcome.assessment is None
+
+    def test_the_two_statuses_carry_different_details(self, tmp_path):
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        broken_dir = tmp_path / "broken"
+        broken_dir.mkdir()
+        _write_summary_csv(str(broken_dir), "median", _PROFILE_A_ROWS,
+                           columns=_MISSING_REQUIRED_COLUMNS)
+
+        empty = build_assessment_result(str(empty_dir), "2026-08-06T00:00:00")
+        broken = build_assessment_result(str(broken_dir), "2026-08-06T00:00:00")
+
+        assert empty.status != broken.status
+        assert empty.detail != broken.detail
+
+    def test_a_malformed_directory_no_longer_renders_an_all_na_assessment(self, tmp_path):
+        """The worst of the four findings: every metric unreadable used to still
+        produce a complete assessment (and so a complete document)."""
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS,
+                           columns=_MISSING_REQUIRED_COLUMNS)
+
+        assert build_assessment_result(tlr, "2026-08-06T00:00:00").assessment is None
+
+    def test_good_directory_is_ok(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
+        _write_summary_csv(tlr, "adolescent", _PROFILE_B_ROWS)
+
+        outcome = build_assessment_result(tlr, "2026-08-06T00:00:00")
+
+        assert outcome.status == "ok"
+        assert isinstance(outcome.assessment, SeverityAssessment)
+
+    def test_outcome_to_dict_is_json_serializable(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
+
+        payload = json.dumps(build_assessment_result(tlr, "2026-08-06T00:00:00").to_dict())
+
+        assert json.loads(payload)["status"] == "ok"
+
+    def test_empty_outcome_to_dict_carries_no_assessment(self, tmp_path):
+        payload = build_assessment_result(str(tmp_path), "2026-08-06T00:00:00").to_dict()
+
+        assert payload["assessment"] is None
+        assert payload["status"] == "empty"
+
+
+class TestBuildAssessmentWrapperContract:
+    """The Optional[SeverityAssessment] contract the GUI runner is typed on."""
+
+    def test_returns_the_assessment_when_usable(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
+
+        assert isinstance(build_assessment(tlr, "2026-08-06T00:00:00"), SeverityAssessment)
+
+    def test_returns_none_for_both_failure_conditions(self, tmp_path):
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        broken_dir = tmp_path / "broken"
+        broken_dir.mkdir()
+        _write_summary_csv(str(broken_dir), "median", _PROFILE_A_ROWS,
+                           columns=_MISSING_REQUIRED_COLUMNS)
+
+        assert build_assessment(str(empty_dir), "2026-08-06T00:00:00") is None
+        assert build_assessment(str(broken_dir), "2026-08-06T00:00:00") is None
+
+
+class TestUsableProfileCount:
+    """Finding 3: the count must reflect contribution, not just file presence."""
+
+    def test_m_equals_n_on_clean_data(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
+        _write_summary_csv(tlr, "adolescent", _PROFILE_B_ROWS)
+
+        assessment = build_assessment(tlr, "2026-08-06T00:00:00")
+
+        assert assessment.profile_count == 2
+        assert assessment.usable_profile_count == 2
+
+    def test_m_is_less_than_n_when_a_file_is_dropped(self, tmp_path):
+        """3 files, 1 malformed: extract_metric_data averages 2, so the old
+        unqualified count named 3 profiles when 2 contributed."""
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
+        _write_summary_csv(tlr, "adolescent", _PROFILE_B_ROWS)
+        _write_summary_csv(tlr, "broken", _PROFILE_A_ROWS,
+                           columns=_MISSING_REQUIRED_COLUMNS)
+
+        assessment = build_assessment(tlr, "2026-08-06T00:00:00")
+
+        assert assessment.profile_count == 3
+        assert assessment.usable_profile_count == 2
+
+    def test_an_unreadable_file_also_reduces_m(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
+        _write_unreadable_csv(tlr, "broken")
+
+        assessment = build_assessment(tlr, "2026-08-06T00:00:00")
+
+        assert (assessment.profile_count, assessment.usable_profile_count) == (2, 1)
+
+    def test_missing_only_the_raw_value_columns_keeps_a_file_usable(self, tmp_path):
+        """Older CSVs predate lbgi/dka_index and are DESIGNED to degrade to 'NA'.
+        Counting them unusable would drop a clean directory to M == 0."""
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS,
+                           columns=_WITHOUT_RAW_VALUE_COLUMNS)
+
+        assessment = build_assessment(tlr, "2026-08-06T00:00:00")
+
+        assert assessment is not None
+        assert assessment.usable_profile_count == assessment.profile_count == 1
+
+    def test_count_is_carried_through_to_dict(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
+        _write_summary_csv(tlr, "broken", _PROFILE_A_ROWS,
+                           columns=_MISSING_REQUIRED_COLUMNS)
+
+        payload = build_assessment(tlr, "2026-08-06T00:00:00").to_dict()
+
+        assert payload["profile_count"] == 2
+        assert payload["usable_profile_count"] == 1
+
+    def test_it_defaults_to_none_for_older_constructors(self):
+        """None means 'not measured' and renders as M == N, so an assessment built
+        without it is unaffected."""
+        assessment = SeverityAssessment(
+            simulation_id="TLR-TEST", subdirectory_name="TLR-TEST",
+            timestamp="2026-08-06T00:00:00", profile_count=2, stages={},
+        )
+
+        assert assessment.usable_profile_count is None
+
+
+class TestClassifySummaryFiles:
+    """The usable/unusable split that defines M."""
+
+    def test_clean_files_are_all_usable(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
+        _write_summary_csv(tlr, "adolescent", _PROFILE_B_ROWS)
+
+        usable, unusable = classify_summary_files(tlr)
+
+        assert len(usable) == 2
+        assert unusable == []
+
+    def test_a_file_missing_a_required_column_is_unusable(self, tmp_path):
+        tlr = str(tmp_path)
+        broken = _write_summary_csv(tlr, "broken", _PROFILE_A_ROWS,
+                                    columns=_MISSING_REQUIRED_COLUMNS)
+
+        usable, unusable = classify_summary_files(tlr)
+
+        assert usable == []
+        assert unusable == [broken]
+
+    def test_every_required_column_is_load_bearing(self, tmp_path):
+        """Each REQUIRED_SUMMARY_COLUMNS entry, dropped on its own, makes the file
+        unusable -- so the constant is not carrying a column that does not matter."""
+        for dropped in REQUIRED_SUMMARY_COLUMNS:
+            directory = tmp_path / f"without_{dropped}"
+            directory.mkdir()
+            columns = [c for c in _SUMMARY_COLUMNS if c != dropped]
+            _write_summary_csv(str(directory), "median", _PROFILE_A_ROWS, columns=columns)
+
+            usable, unusable = classify_summary_files(str(directory))
+
+            assert usable == [], f"{dropped} should be required"
+            assert len(unusable) == 1
+
+    def test_an_empty_directory_splits_to_two_empty_lists(self, tmp_path):
+        assert classify_summary_files(str(tmp_path)) == ([], [])
+
+
+class TestGetProfileMetricsStatus:
+    """Finding 2 at the source: absent and malformed are now separate."""
+
+    def test_no_files_is_no_data(self, tmp_path):
+        assert get_profile_metrics(str(tmp_path)) == (None, "no_data")
+
+    def test_missing_required_columns_is_malformed(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS,
+                           columns=_MISSING_REQUIRED_COLUMNS)
+
+        profile_data, status = get_profile_metrics(tlr)
+
+        assert status == "malformed_data"
+        assert profile_data is None
+
+    def test_an_unreadable_file_is_malformed(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_unreadable_csv(tlr, "median")
+
+        assert get_profile_metrics(tlr)[1] == "malformed_data"
+
+    def test_clean_data_is_ok(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
+
+        profile_data, status = get_profile_metrics(tlr)
+
+        assert status == "ok"
+        assert set(profile_data) == {"median"}
+
+
+class TestDetectOutliersStatus:
+    """Finding 2 at the boundary the renderer reads."""
+
+    def test_malformed_data_is_not_reported_as_no_data(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
+        _write_summary_csv(tlr, "broken", _PROFILE_A_ROWS,
+                           columns=_MISSING_REQUIRED_COLUMNS)
+
+        findings, status = detect_outliers(tlr)
+
+        assert status == "malformed_data"
+        assert findings == []
+
+    def test_a_genuinely_absent_directory_is_still_no_data(self, tmp_path):
+        assert detect_outliers(str(tmp_path)) == ([], "no_data")
+
+    def test_one_profile_is_still_single_profile(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
+
+        assert detect_outliers(tlr)[1] == "single_profile"
+
+    def test_clean_multi_profile_data_is_still_ok(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
+        _write_summary_csv(tlr, "adolescent", _PROFILE_B_ROWS)
+
+        assert detect_outliers(tlr)[1] == "ok"
+
+    def test_the_status_reaches_the_assessment(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS)
+        _write_summary_csv(tlr, "broken", _PROFILE_A_ROWS,
+                           columns=_MISSING_REQUIRED_COLUMNS)
+
+        assert build_assessment(tlr, "2026-08-06T00:00:00").outlier_status == "malformed_data"
+
+
+class TestOptionalColumnIsNotCalledMalformed:
+    """An older CSV that legitimately degrades to 'NA' was labeled malformed on
+    the console -- valid data reported as broken, the inverse of finding 2."""
+
+    def test_absent_optional_column_is_reported_as_na_not_malformed(self, tmp_path, capsys):
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS,
+                           columns=_WITHOUT_RAW_VALUE_COLUMNS)
+
+        extract_metric_data(tlr, "lbgi")
+        output = capsys.readouterr().out
+
+        assert "malformed" not in output
+        assert "will report NA" in output
+
+    def test_absent_required_column_is_still_reported_as_malformed(self, tmp_path, capsys):
+        tlr = str(tmp_path)
+        _write_summary_csv(tlr, "median", _PROFILE_A_ROWS,
+                           columns=_MISSING_REQUIRED_COLUMNS)
+
+        extract_metric_data(tlr, "lbgi_risk_score")
+
+        assert "malformed" in capsys.readouterr().out

--- a/post_processing/test_severity_model.py
+++ b/post_processing/test_severity_model.py
@@ -896,3 +896,95 @@ class TestZeroTarOutlierStillFlagged:
         assert status == "ok"
         hypo = [f for f in findings if f.harm_type == "Hypoglycemia"]
         assert {f.profile for f in hypo} == {"severe"}
+
+
+class TestIncompleteStagesIsNotReportedAsAbsent:
+    """The third condition that used to hide inside 'no_data' (TRSET-28 Decision B).
+
+    Profiles that parse but where none carries all three stages is neither absence
+    nor corruption -- it is a run that produced only some stages, a recoverable
+    configuration problem that was reported with the same sentence as a missing
+    directory.
+    """
+
+    def _write_partial_stage_profile(self, directory, profile, stems):
+        """A profile whose rows cover only `stems`, so it is never stage-complete."""
+        rows = [(f"{stem}_{profile}", 80.0, 1.0, 20.0, 1, 0) for stem in stems]
+        return _write_summary_csv(directory, profile, rows, columns=_OUTLIER_COLUMNS)
+
+    def test_profiles_missing_a_stage_report_incomplete_not_no_data(self, tmp_path):
+        tlr = str(tmp_path)
+        for profile in ("median", "adolescent"):
+            self._write_partial_stage_profile(
+                tlr, profile, ("pre-Loop_NoMitigations_t1", "pre-noLoop_t1"),
+            )  # no post- row anywhere
+
+        findings, status = detect_outliers(tlr)
+
+        assert status == "incomplete_stages"
+        assert findings == []
+
+    def test_a_single_missing_stage_is_enough(self, tmp_path):
+        """Only the post stage is absent; pre and no_loop are fully populated."""
+        tlr = str(tmp_path)
+        self._write_partial_stage_profile(
+            tlr, "median", ("pre-Loop_NoMitigations_t1", "pre-noLoop_t1"),
+        )
+
+        assert detect_outliers(tlr)[1] == "incomplete_stages"
+
+    def test_no_profile_names_at_all_is_still_no_data(self, tmp_path):
+        """An aggregate-only directory: summary CSVs exist but none is a per-profile
+        file, so no per-profile results exist to compare. Genuine absence."""
+        tlr = str(tmp_path)
+        path = os.path.join(tlr, f"summary_results_{_NARROW_STEM}.csv")
+        with open(path, "w") as fh:
+            fh.write(",".join(_OUTLIER_COLUMNS) + "\n")
+            fh.write("pre-Loop_NoMitigations_t1_x,80.0,1.0,20.0,1,0\n")
+
+        assert detect_outliers(tlr)[1] == "no_data"
+
+    def test_an_empty_directory_is_still_no_data(self, tmp_path):
+        assert detect_outliers(str(tmp_path))[1] == "no_data"
+
+    def test_malformed_still_outranks_incomplete(self, tmp_path):
+        """A directory that is BOTH unreadable and thin reports the unreadability --
+        the more actionable fault, and the one that makes the rest unknowable."""
+        tlr = str(tmp_path)
+        self._write_partial_stage_profile(
+            tlr, "median", ("pre-Loop_NoMitigations_t1",),
+        )
+        _write_summary_csv(tlr, "broken", _PROFILE_A_ROWS,
+                           columns=_MISSING_REQUIRED_COLUMNS)
+
+        assert detect_outliers(tlr)[1] == "malformed_data"
+
+    def test_one_complete_profile_is_still_single_profile(self, tmp_path):
+        """A complete profile alongside incomplete ones is the single-profile case,
+        not the incomplete one -- the check is 'none complete', not 'any incomplete'."""
+        tlr = str(tmp_path)
+        _write_outlier_profile(tlr, "complete", tar=20.0, lbgi=1, dka=0)
+        self._write_partial_stage_profile(
+            tlr, "partial", ("pre-Loop_NoMitigations_t1",),
+        )
+
+        assert detect_outliers(tlr)[1] == "single_profile"
+
+    def test_complete_profiles_are_still_ok(self, tmp_path):
+        tlr = str(tmp_path)
+        _write_outlier_profile(tlr, "median", tar=20.0, lbgi=1, dka=0)
+        _write_outlier_profile(tlr, "adolescent", tar=25.0, lbgi=1, dka=0)
+
+        assert detect_outliers(tlr)[1] == "ok"
+
+    def test_the_status_reaches_the_assessment(self, tmp_path):
+        tlr = str(tmp_path)
+        for profile in ("median", "adolescent"):
+            self._write_partial_stage_profile(
+                tlr, profile, ("pre-Loop_NoMitigations_t1", "pre-noLoop_t1"),
+            )
+
+        assessment = build_assessment(tlr, "2026-08-06T00:00:00")
+
+        assert assessment is not None, "readable data must still produce a document"
+        assert assessment.outlier_status == "incomplete_stages"

--- a/tests/test_gui_runner.py
+++ b/tests/test_gui_runner.py
@@ -2,7 +2,7 @@
 Unit tests for gui_runner.py, the single validated entry point Phase 3's
 Streamlit GUI (and any other consumer) calls to run a risk assessment.
 
-build_risk_sim_generator, run_simulations, build_assessment, and
+build_risk_sim_generator, run_simulations, build_assessment_result, and
 ConfigValidator are monkeypatched throughout -- these are exercised for real
 in the separately-approved Phase 3 integration test plan; these tests target
 gui_runner's own orchestration logic (finalize-once-per-TLR-dir, progress
@@ -149,6 +149,17 @@ def run_env(monkeypatch):
     shutil.rmtree(save_dir, ignore_errors=True)
 
 
+# build_assessment_result returns an AssessmentOutcome (TRSET-28), so the fakes
+# below return the real dataclass rather than a bare assessment-or-None -- a fake
+# with the wrong shape would pass while the GUI's own status branch broke.
+def _ok_outcome(assessment=None):
+    return gui_runner.AssessmentOutcome(assessment or SimpleNamespace(), "ok")
+
+
+def _no_assessment_outcome(status="empty", detail="nothing ran in this directory"):
+    return gui_runner.AssessmentOutcome(None, status, detail)
+
+
 def test_happy_path_finalizes_once_per_risk_dir(run_env, monkeypatch):
     save_dir, monkeypatch = run_env
 
@@ -162,11 +173,11 @@ def test_happy_path_finalizes_once_per_risk_dir(run_env, monkeypatch):
 
     assessment_calls = []
 
-    def fake_build_assessment(tlr_dir, timestamp):
+    def fake_build_assessment_result(tlr_dir, timestamp):
         assessment_calls.append(tlr_dir)
-        return SimpleNamespace(simulation_id=os.path.basename(tlr_dir))
+        return _ok_outcome(SimpleNamespace(simulation_id=os.path.basename(tlr_dir)))
 
-    monkeypatch.setattr(gui_runner, "build_assessment", fake_build_assessment)
+    monkeypatch.setattr(gui_runner, "build_assessment_result", fake_build_assessment_result)
 
     progress_calls = []
     result = gui_runner.run_risk_assessment(
@@ -203,8 +214,12 @@ def test_cancel_mid_run_stops_before_finalizing_in_progress_dir(run_env, monkeyp
     monkeypatch.setattr(gui_runner, "_list_target_risk_dirs", lambda *a, **kw: ["TLR-1", "TLR-2"])
 
     assessment_calls = []
-    monkeypatch.setattr(gui_runner, "build_assessment",
-                         lambda tlr_dir, timestamp: assessment_calls.append(tlr_dir))
+
+    def fake_build_assessment_result(tlr_dir, timestamp):
+        assessment_calls.append(tlr_dir)
+        return _ok_outcome()
+
+    monkeypatch.setattr(gui_runner, "build_assessment_result", fake_build_assessment_result)
 
     result = gui_runner.run_risk_assessment("unused_config_dir", cancel_event=cancel_event)
 
@@ -236,13 +251,72 @@ def test_none_assessment_is_included_not_dropped(run_env, monkeypatch):
     generator_items = [("TLR-1", "scenario_a.json", _fake_sim_suite())]
     monkeypatch.setattr(gui_runner, "build_risk_sim_generator", lambda *a, **kw: iter(generator_items))
     monkeypatch.setattr(gui_runner, "_list_target_risk_dirs", lambda *a, **kw: ["TLR-1"])
-    monkeypatch.setattr(gui_runner, "build_assessment", lambda tlr_dir, timestamp: None)
+    monkeypatch.setattr(gui_runner, "build_assessment_result",
+                        lambda tlr_dir, timestamp: _no_assessment_outcome())
 
     result = gui_runner.run_risk_assessment("unused_config_dir")
 
     assert len(result.risk_dir_results) == 1
     assert result.risk_dir_results[0].risk_dir_name == "TLR-1"
     assert result.risk_dir_results[0].assessment is None
+
+
+class TestAssessmentStatusIsSurfaced:
+    """TRSET-28: a GUI could only say "no data" for a directory whose data was in
+    fact corrupt, because both conditions arrived as a bare None."""
+
+    def _run_with(self, monkeypatch, outcome):
+        monkeypatch.setattr(gui_runner, "build_risk_sim_generator",
+                            lambda *a, **kw: iter([("TLR-1", "scenario_a.json", _fake_sim_suite())]))
+        monkeypatch.setattr(gui_runner, "_list_target_risk_dirs", lambda *a, **kw: ["TLR-1"])
+        monkeypatch.setattr(gui_runner, "build_assessment_result",
+                            lambda tlr_dir, timestamp: outcome)
+        result = gui_runner.run_risk_assessment("unused_config_dir")
+        return result.risk_dir_results[0]
+
+    def test_an_empty_directory_reports_empty(self, run_env, monkeypatch):
+        save_dir, monkeypatch = run_env
+
+        risk_dir_result = self._run_with(monkeypatch, _no_assessment_outcome("empty", "nothing ran"))
+
+        assert risk_dir_result.assessment_status == "empty"
+        assert risk_dir_result.assessment_detail == "nothing ran"
+
+    def test_a_malformed_directory_reports_malformed(self, run_env, monkeypatch):
+        save_dir, monkeypatch = run_env
+
+        risk_dir_result = self._run_with(
+            monkeypatch, _no_assessment_outcome("malformed", "3 files present, none usable")
+        )
+
+        assert risk_dir_result.assessment_status == "malformed"
+        assert risk_dir_result.assessment_detail == "3 files present, none usable"
+
+    def test_the_two_are_distinguishable(self, run_env, monkeypatch):
+        """The whole point: both used to be assessment=None and nothing else."""
+        save_dir, monkeypatch = run_env
+
+        empty = self._run_with(monkeypatch, _no_assessment_outcome("empty"))
+        malformed = self._run_with(monkeypatch, _no_assessment_outcome("malformed", "unreadable"))
+
+        assert empty.assessment is malformed.assessment is None
+        assert empty.assessment_status != malformed.assessment_status
+
+    def test_a_usable_directory_reports_ok(self, run_env, monkeypatch):
+        save_dir, monkeypatch = run_env
+
+        risk_dir_result = self._run_with(monkeypatch, _ok_outcome())
+
+        assert risk_dir_result.assessment_status == "ok"
+        assert risk_dir_result.assessment is not None
+
+    def test_the_new_fields_default_so_positional_construction_still_works(self):
+        """Appended after the existing fields, so a consumer building this
+        positionally the old way is unaffected."""
+        risk_dir_result = gui_runner.RiskDirRunResult("TLR-1", None, ["a.png"], {})
+
+        assert risk_dir_result.assessment_status == "ok"
+        assert risk_dir_result.assessment_detail == ""
 
 
 def test_target_risk_dir_passed_through_to_generator(run_env, monkeypatch):
@@ -286,7 +360,8 @@ def test_trace_paths_grouped_by_scenario_file_and_keyed_by_sim_id(run_env, monke
     generator_items = [("TLR-1", name, _fake_sim_suite()) for name in sims_by_scenario]
     monkeypatch.setattr(gui_runner, "build_risk_sim_generator", lambda *a, **kw: iter(generator_items))
     monkeypatch.setattr(gui_runner, "_list_target_risk_dirs", lambda *a, **kw: ["TLR-1"])
-    monkeypatch.setattr(gui_runner, "build_assessment", lambda tlr_dir, timestamp: SimpleNamespace())
+    monkeypatch.setattr(gui_runner, "build_assessment_result",
+                        lambda tlr_dir, timestamp: _ok_outcome())
     monkeypatch.setattr(
         gui_runner, "run_simulations",
         lambda sims, **kw: (sims_by_scenario[kw["name"]], None),
@@ -318,7 +393,8 @@ def test_trace_paths_are_reset_between_risk_dirs(run_env, monkeypatch):
     ]
     monkeypatch.setattr(gui_runner, "build_risk_sim_generator", lambda *a, **kw: iter(generator_items))
     monkeypatch.setattr(gui_runner, "_list_target_risk_dirs", lambda *a, **kw: ["TLR-1", "TLR-2"])
-    monkeypatch.setattr(gui_runner, "build_assessment", lambda tlr_dir, timestamp: SimpleNamespace())
+    monkeypatch.setattr(gui_runner, "build_assessment_result",
+                        lambda tlr_dir, timestamp: _ok_outcome())
     monkeypatch.setattr(
         gui_runner, "run_simulations",
         lambda sims, **kw: (per_scenario_sims[kw["name"]], None),
@@ -362,8 +438,8 @@ def test_run_writes_metadata_json_with_the_assessment_timestamp(run_env, monkeyp
                         lambda *a, **kw: iter([("TLR-1", "scenario_a.json", _fake_sim_suite())]))
     monkeypatch.setattr(gui_runner, "_list_target_risk_dirs", lambda *a, **kw: ["TLR-1"])
     monkeypatch.setattr(
-        gui_runner, "build_assessment",
-        lambda tlr_dir, timestamp: assessment_timestamps.append(timestamp) or SimpleNamespace(),
+        gui_runner, "build_assessment_result",
+        lambda tlr_dir, timestamp: assessment_timestamps.append(timestamp) or _ok_outcome(),
     )
 
     gui_runner.run_risk_assessment("unused_config_dir")
@@ -393,7 +469,8 @@ def test_metadata_json_is_written_before_any_simulation_runs(run_env, monkeypatc
     monkeypatch.setattr(gui_runner, "build_risk_sim_generator",
                         lambda *a, **kw: iter([("TLR-1", "scenario_a.json", _fake_sim_suite())]))
     monkeypatch.setattr(gui_runner, "_list_target_risk_dirs", lambda *a, **kw: ["TLR-1"])
-    monkeypatch.setattr(gui_runner, "build_assessment", lambda tlr_dir, timestamp: SimpleNamespace())
+    monkeypatch.setattr(gui_runner, "build_assessment_result",
+                        lambda tlr_dir, timestamp: _ok_outcome())
     monkeypatch.setattr(gui_runner, "run_simulations", _observing_run_simulations)
 
     gui_runner.run_risk_assessment("unused_config_dir")

--- a/tidepool_data_science_simulator/projects/risk/gui_runner.py
+++ b/tidepool_data_science_simulator/projects/risk/gui_runner.py
@@ -4,7 +4,7 @@ in-process. GUI and other consumers (ad hoc scripts) call only this module;
 none of them reach into simulator internals directly.
 
 Wraps loop_risk_v2_0.build_risk_sim_generator + run_simulations +
-severity_model.build_assessment. Library-browsing/resolution (listing
+severity_model.build_assessment_result. Library-browsing/resolution (listing
 available config collections, mapping a chosen name to its path) is
 deliberately NOT handled here -- it lives in the GUI's view layer, so a
 future "configure parameters directly" mode can hand this module a
@@ -41,7 +41,16 @@ _POST_PROCESSING_DIR = os.path.join(PROJECT_ROOT_DIR, "post_processing")
 if _POST_PROCESSING_DIR not in sys.path:
     sys.path.insert(0, _POST_PROCESSING_DIR)
 
-from severity_model import build_assessment, SeverityAssessment  # noqa: E402
+from severity_model import (  # noqa: E402
+    build_assessment_result,
+    AssessmentOutcome,  # noqa: F401  (re-exported: GUI consumers branch on .status)
+    SeverityAssessment,
+    # This module now calls build_assessment_result, but build_assessment stays
+    # importable from here: it was reachable on this entry point before TRSET-28,
+    # and dropping the name would break a consumer that imports it rather than
+    # giving them a reason to migrate.
+    build_assessment,  # noqa: F401  (re-export, superseded by the *_result form)
+)
 # Re-exported for GUI consumers (TRSET-23). severity_model remains the single
 # source of truth for stage identity; it lives in the simulator's top-level
 # post_processing/ dir, which is NOT part of the installed package and is only
@@ -84,10 +93,19 @@ class ConfigValidationResult:
 
 @dataclass
 class RiskDirRunResult:
-    """Outcome for one TLR-* directory. assessment is None when build_assessment
-    found no usable data for it -- surfaced explicitly, never silently dropped.
-    (severity_model.build_assessment_result additionally distinguishes an empty
-    directory from malformed data; adopting it here is a follow-up to TRSET-28.)
+    """Outcome for one TLR-* directory. assessment is None when the directory
+    yielded no usable data -- surfaced explicitly, never silently dropped.
+
+    assessment_status says WHY it is None (TRSET-28), straight from
+    severity_model.AssessmentOutcome: 'ok' (assessment is present), 'empty'
+    (nothing ran in this directory), or 'malformed' (summary results ARE present
+    and cannot be read). Those last two used to be indistinguishable, so a GUI
+    could only ever say "no data" for a directory whose data was in fact corrupt.
+    assessment_detail is the reportable reason, suitable for display as-is.
+
+    Both are keyword-defaulted and appended after the existing fields, so a
+    consumer constructing or unpacking this positionally is unaffected.
+
     png_paths has one entry per scenario config file run in this directory.
 
     trace_paths (TRSET-23) exposes each completed sim's per-run ``<sim_id>.tsv``
@@ -102,6 +120,8 @@ class RiskDirRunResult:
     assessment: Optional[SeverityAssessment]
     png_paths: list = field(default_factory=list)
     trace_paths: dict = field(default_factory=dict)
+    assessment_status: str = 'ok'
+    assessment_detail: str = ''
 
 
 @dataclass
@@ -209,9 +229,12 @@ def run_risk_assessment(
     def _finalize(risk_dir_name, png_paths, trace_paths):
         nonlocal completed_count
         risk_result_dirpath = os.path.join(save_dir, risk_dir_name)
-        assessment = build_assessment(risk_result_dirpath, timestamp)
+        outcome = build_assessment_result(risk_result_dirpath, timestamp)
         risk_dir_results.append(
-            RiskDirRunResult(risk_dir_name, assessment, png_paths, trace_paths)
+            RiskDirRunResult(
+                risk_dir_name, outcome.assessment, png_paths, trace_paths,
+                outcome.status, outcome.detail,
+            )
         )
         completed_count += 1
         if progress_callback is not None:

--- a/tidepool_data_science_simulator/projects/risk/gui_runner.py
+++ b/tidepool_data_science_simulator/projects/risk/gui_runner.py
@@ -86,6 +86,8 @@ class ConfigValidationResult:
 class RiskDirRunResult:
     """Outcome for one TLR-* directory. assessment is None when build_assessment
     found no usable data for it -- surfaced explicitly, never silently dropped.
+    (severity_model.build_assessment_result additionally distinguishes an empty
+    directory from malformed data; adopting it here is a follow-up to TRSET-28.)
     png_paths has one entry per scenario config file run in this directory.
 
     trace_paths (TRSET-23) exposes each completed sim's per-run ``<sim_id>.tsv``


### PR DESCRIPTION
Ticket: [TRSET-28](https://tidepool.atlassian.net/browse/TRSET-28) — follow-up to TRSET-27 (#54).

Four silent or ambiguous failure behaviors in the risk-severity post-processing layer, plus the `gui_runner` migration that lets the GUI see the difference.

## The four findings

**1. `build_assessment` collapsed two conditions into a bare `None`.** An empty/not-yet-run directory and real-but-malformed data both reached `process_results_directory` as the same `"no usable summary results data"`, so no caller could tell "nothing ran here" from "the data is broken." `build_assessment_result` now returns a typed `AssessmentOutcome` with `status ∈ {'ok', 'empty', 'malformed'}` and a reportable `detail`. `build_assessment` stays a wrapper returning `Optional[SeverityAssessment]`. Both failures remain **partial** outcomes for one directory, preserving TRSET-27's fatal-vs-partial split.

**2. Malformed data was rendered to the reader as *absent* data.** `get_profile_metrics` swallowed any exception into `None`, `detect_outliers` mapped that to `'no_data'`, and the renderer emitted `"Data not available for outlier analysis."` — a regulatory document asserting the data was unavailable when in fact it was unusable. There is now a `'malformed_data'` status with its own text. It deliberately does not name the offending file; the path stays in the console diagnostic and in `outcome.detail`.

**3. The profile count could overstate what was aggregated.** `count_profiles` counted files while `extract_metric_data` dropped a malformed one and averaged the rest, so "3 virtual patient profiles aggregated" could name 3 when 2 contributed. The assessment now carries N (present) and M (usable). `M == 0, N > 0` produces **no document** — it used to produce a complete document with every metric `NA`/`0`, the worst of the four findings.

**4. Five call sites used two different globs.** `build_assessment` required `summary_results_Simulation-Configuration-TLR*.csv` while the four helpers used the looser `summary_results_*.csv`, so a directory every helper could read was reported unusable. All five now go through `find_summary_files()` over a single `SUMMARY_RESULTS_GLOB`.

## Rendered output

Byte-identical on the clean path (M == N, well-formed data), verified by rendering the same fixture through the pre-change module from git and `diff`ing — 1846 bytes, identical. Only degraded paths change text, per the before/after sample approved before implementation:

| | Before | Now |
|---|---|---|
| M == N | `2 virtual patient profiles aggregated for this summary.` | *unchanged* |
| 0 < M < N | `3 virtual patient profiles aggregated for this summary.` (named 3; 2 contributed) | `2 of 3 virtual patient profiles aggregated for this summary. 1 summary results file could not be read.` |
| malformed outlier input | `Data not available for outlier analysis.` | `Outlier analysis not performed: profile data is present but could not be read. Check data configuration.` |
| M == 0, N > 0 | a full document of `NA`/`0` | no document; reported as malformed |

## Two problems found while reading that the ticket did not cover

**`summary_files[0]` becomes order-dependent once the glob widens.** `glob.glob` returns filesystem order; under the old narrow pattern every match carried the same `Simulation-Configuration-TLR` stem so that was harmless. Left alone, a directory mixing TLR-named and non-TLR-named CSVs could get `None` and be skipped where it renders today. Fixed with a sorted glob plus `resolve_simulation_id()`, which takes the ID from the first filename that *yields* one.

**`TestRtfOutputUnchanged` cannot detect a text change.** It compares the written file against `render_rtf`'s own output — self-consistency, not a golden file — so it would pass even if every clean-path string changed. The two strings TRSET-28 touches are now pinned verbatim.

Also: `extract_metric_data` reported `"CSV file malformed"` when an *optional* column was absent, which fired for `lbgi`/`dka_index` on older CSVs designed to degrade to `NA` — valid data labeled broken. Required columns are named once in `REQUIRED_SUMMARY_COLUMNS` (the verdict inputs), which is also what defines M, so an older-format directory cannot fall to `M == 0`.

## `gui_runner` migration (second commit)

The GUI runner was the last caller on the wrapper, so a corrupt directory reached the GUI as the same bare `None` an empty one did. `RiskDirRunResult` gains `assessment_status` and `assessment_detail`, keyword-defaulted and appended after the existing fields — positional construction and existing field access unaffected, and a GUI branching only on `assessment is None` still renders correctly. `build_assessment` stays importable from `gui_runner` so a consumer importing it is not broken.

## Breaking changes

- `get_profile_metrics` returns `(profile_data, status)`, not a bare `profile_data`/`None`.
- `detect_outliers`' status set gains `'malformed_data'`; a consumer branching on status must handle it.

Migration guidance in `post_processing/README_severity_model.md`. `build_assessment`'s signature is unchanged.

## Testing

69 tests added. **170 passed** across `test_severity_model.py`, `test_create_severity_summary.py` and `tests/test_gui_runner.py`. Full suite **649 passed / 8 failed / 5 skipped** — the 8 are pre-existing and unrelated (all in untracked local scratch files: `test_consensus_risk_list.py`, `test_jira_risk_probabilities.py`, `test_simulation_results_columns.py`), verified identical on a stash of this change.

Two things verified out-of-band because the suite could not: clean-path RTF byte-identity against the pre-change module, and `gui_runner`'s migrated `_finalize` line against real good/empty/malformed directories (every test in that file mocks the assessment call).

## Out of scope

The `detect_outliers` hyperglycemia deviation (`hyper_score = 1 if tar < 12.0 else 2`, no zero case) is preserved exactly — a separate correctness decision. Also deliberately deferred: splitting the third condition still inside `'no_data'` (profiles parse but none complete across all three stages), and analyzing the M usable profiles instead of abandoning outlier analysis on the first malformed file — that would change which outliers are *found*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TRSET-28]: https://tidepool.atlassian.net/browse/TRSET-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ