### PR TITLE
[bugfix] remove the carb-entry upper bound from config validation

### DIFF
--- a/tidepool_data_science_simulator/validation/value_validators.py
+++ b/tidepool_data_science_simulator/validation/value_validators.py
@@ -662,10 +662,10 @@ class ValueValidators:
         if 'value' in entry:
             try:
                 value = float(entry['value'])
-                if not 0 < value <= 500:
+                if value <= 0:
                     errors.append(ValidationError(
                         f"{field_path}.value",
-                        "Carb value must be between 0 and 500 grams",
+                        "Carb value must be greater than 0 grams",
                         value
                     ))
             except (ValueError, TypeError):


### PR DESCRIPTION
`ValueValidators.validate_carb_entry` rejected any carb entry over 500 g, so a scenario config the simulator runs correctly could not pass validation. This removes the ceiling and keeps the lower guard.

## What changed

```diff
- if not 0 < value <= 500:
+ if value <= 0:
      errors.append(ValidationError(
          f"{field_path}.value",
-         "Carb value must be between 0 and 500 grams",
+         "Carb value must be greater than 0 grams",
```

| Carb value | Before | Now |
|---|---|---|
| `1` … `500` | accepted | *unchanged* |
| `501`, `825`, `5000` | **rejected** | accepted |
| `0`, `-10` | rejected | *unchanged* |
| `"abc"` | rejected (non-numeric) | *unchanged* |

## Why

The bound was a hardcoded literal with no comment, constant, or referenced clinical basis — unlike the neighbouring `validate_bolus_entry`, whose 50 U cap at least reads as a device limit. 500 g is low enough to reject legitimate high-carb scenarios while being far too high to catch the typo it presumably guards against (a fat-fingered `5000` was rejected; `499` was not). It wasn't doing the job a ceiling is for.

Dropping it rather than raising it avoids re-litigating an arbitrary number. If reviewers want a ceiling, it should be a named constant with a documented basis — happy to add one in this PR instead.

## Scope

`ConfigValidator` has two callers and **both** lose the ceiling:

- `scripts/validate_configs.py`
- `tidepool_data_science_simulator/projects/risk/gui_runner.py`

Worth stating plainly, since the motivating case was only the CLI. A GUI run that previously refused a >500 g config will now proceed.

Note this validator is not the only path into the simulator: `scenario_json_parser_v2.validate_carb_entry` is a bare `pass`, so configs loaded directly through the parser were never bounds-checked at all. That's context, not the justification — the parser's silence is arguably its own bug, and this PR doesn't touch it.

## Validation

- Full suite on this branch: **118 passed, 5 skipped, 0 failed**.
- `tests/test_validate_configs_integration.py`: **27/27**.
- No existing test asserted the 500 g bound, so nothing needed updating — which is also why no test regressed. The boundary table above was verified by exercising `validate_carb_entry` directly on this branch.

## Out of scope

Deliberately untouched, all in the same function or file:

- The carb `duration` bound, `0 < duration <= 600` minutes.
- The two unrelated `<= 500` bounds — glucose sensitivity factor (line 248) and basal blood glucose (line 282). Different units that happen to share the number.
- The `pass` stub in `scenario_json_parser_v2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
