### PR TITLE
[bugfix] restore parser access to migrated reusable simulation subdirectories

### DIFF
--- a/tidepool_data_science_simulator/makedata/scenario_json_parser_v2.py
+++ b/tidepool_data_science_simulator/makedata/scenario_json_parser_v2.py
@@ -451,7 +451,8 @@ class ScenarioParserV2(SimulationParser):
         # Define subdirectory search paths based on folder type
         subdirectories = []
         if "simulations" in folder_path:
-            subdirectories = ["base", "suspend", "loop_versions", "specialized"]
+            subdirectories = ["base", "suspend", "loop_versions", "specialized",
+                              "versions", "1xComparator", "custom_presets"]
         elif "metabolism_settings" in folder_path:
             subdirectories = ["profiles", "suspensions", "presets", "versions", "types"]
 


### PR DESCRIPTION
A config could pass `scripts/validate_configs.py` cleanly and then fail mid-run:

```
Error in main loop: Could not load pointer file t2_resistant_v1. Searched in:
  .../reusable/simulations/t2_resistant_v1,
  .../reusable/simulations/base/t2_resistant_v1,
  .../reusable/simulations/suspend/t2_resistant_v1,
  .../reusable/simulations/loop_versions/t2_resistant_v1,
  .../reusable/simulations/specialized/t2_resistant_v1
```

`t2_resistant_v1.json` lives in `reusable/simulations/versions/`, which the parser never searched.

## Root cause

The subdirectory search list is duplicated in two places, and they drifted:

| | `simulations` subdirectories searched |
|---|---|
| `ScenarioParserV2.load_pointer` | `base`, `suspend`, `loop_versions`, `specialized` |
| `ConfigValidator._subdirectories_for_ref` | …same four, **plus** `versions`, `1xComparator`, `custom_presets` |

Commit `0264cf9c` *"Migrate reusable metabolism_settings and simulation files to appropriate subdirectories"* moved the files and updated the validator's list, but not the parser's. Two consequences:

- The parser searches `loop_versions/`, which **does not exist** anywhere in the repo.
- `versions/` (1985 files), `1xComparator/` (236) and `custom_presets/` (227) were unreachable at runtime.

The net effect is a validator **more permissive than the runtime it validates for** — the failure mode a config validator exists to prevent.

## What changed

```diff
  if "simulations" in folder_path:
-     subdirectories = ["base", "suspend", "loop_versions", "specialized"]
+     subdirectories = ["base", "suspend", "loop_versions", "specialized",
+                       "versions", "1xComparator", "custom_presets"]
```

Parity with the validator, rather than narrowing the validator to match the parser. Narrowing would make the validator honest but turn 365 references into errors and unblock nothing — the referenced files exist and are plainly intended to be reachable.

## Scale

Auditing every short-form `reusable.simulations.*` reference in `scenario_configs/` (434 distinct, 18213 occurrences):

| | Before | After |
|---|---|---|
| resolve at runtime | 68 | **433** |
| pass validation, fail at runtime | **365** (5563 occurrences) | 0 |
| fail under both | 1 | 1 |

Top items in the silent-pass class were `t2_median_v1` (581), `t2_sensitive_v1` (560), `t2_resistant_v1` (552) and the `*_swift` variants.

The one remaining failure, `reusable.simulations.t2_test_simulation_no_controller_v1` (5 occurrences, all under `tidepool_risk_test/loop_risk_test/TLR-000-T2-temp/`), references a file absent from the repo. It failed under both lists before this change — a data gap, not a search-path gap, and out of scope here.

## Why this is safe

`load_pointer` tries every search path for `.json` before any `.csv`, so adding paths could in principle re-point an already-resolving reference. The new entries are **appended** after the existing four, so first-match-wins is preserved.

Verified rather than argued: of the **242** names resolvable under the old list, **0** resolve to a different path under the new one.

## Testing

- Full suite: **372 passed, 5 skipped, 3 failed**. The 3 (`tests/test_simulation_results_columns.py`) were confirmed pre-existing by stashing this change and re-running — identical failures.
- The config from the original report now loads end-to-end through `ScenarioParserV2`, with all pointers resolved.
- The 434-reference audit above was run against the live `load_pointer`, not a reimplementation of its rules.

## Out of scope

Deliberately untouched — all latent (no current references exercise them), unlike the `simulations` drift which was actively breaking runs:

- **The duplication itself.** Two hardcoded lists with no shared source of truth is what allowed this. This PR fixes the drift, not the design. A single shared constant would prevent recurrence and is worth its own change.
- `metabolism_settings`: both lists search a phantom `versions/`, and both omit the real `activity_presets/`. They agree, so there is no validator/runtime divergence.
- `physical_activities`: the parser has no branch at all, while the validator lists `profiles`, `activities`, `templates` (of which only `profiles` exists; the real `extended_duration/` is in neither). No short-form references to these exist today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
